### PR TITLE
[FIXES] Generic meet scheme fixes, decoupling of binders logics

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -146,7 +146,6 @@ jobs:
 
       - name: Update nightly tag
         uses: EndBug/latest-tag@latest
-        if: github.ref_name == 'dev'
         id: update-nightly-tag
         with:
           ref: nightly

--- a/src/engine/core/database/logic.ts
+++ b/src/engine/core/database/logic.ts
@@ -29,7 +29,7 @@ import {
 export function saveObjectLogic(object: ClientObject, packet: NetPacket): void {
   const state: IRegistryObjectState = registry.objects.get(object.id());
 
-  openSaveMarker(packet, "object" + object.name());
+  openSaveMarker(packet, object.name());
 
   packet.w_stringZ(state.jobIni ? state.jobIni : "");
   packet.w_stringZ(state.iniFilename ? state.iniFilename : "");
@@ -40,13 +40,12 @@ export function saveObjectLogic(object: ClientObject, packet: NetPacket): void {
   packet.w_s32((state.activationTime || 0) - time_global());
   writeTimeToPacket(packet, state.activationGameTime);
 
-  // todo: Active section or active scheme?
   if (state.activeScheme) {
     emitSchemeEvent(object, state[state.activeScheme] as IBaseSchemeState, ESchemeEvent.SAVE);
   }
 
   savePortableStore(object, packet);
-  closeSaveMarker(packet, "object" + object.name());
+  closeSaveMarker(packet, object.name());
 }
 
 /**
@@ -58,7 +57,7 @@ export function saveObjectLogic(object: ClientObject, packet: NetPacket): void {
 export function loadObjectLogic(object: ClientObject, reader: NetProcessor): void {
   const state: IRegistryObjectState = registry.objects.get(object.id());
 
-  openLoadMarker(reader, "object" + object.name());
+  openLoadMarker(reader, object.name());
 
   const jobIni: Optional<TPath> = reader.r_stringZ();
   const iniFilename: Optional<TName> = reader.r_stringZ();
@@ -77,5 +76,5 @@ export function loadObjectLogic(object: ClientObject, reader: NetProcessor): voi
 
   loadPortableStore(object.id(), reader);
 
-  closeLoadMarker(reader, "object" + object.name());
+  closeLoadMarker(reader, object.name());
 }

--- a/src/engine/core/database/registry.test.ts
+++ b/src/engine/core/database/registry.test.ts
@@ -4,10 +4,11 @@ import { registry } from "@/engine/core/database/registry";
 
 describe("registry storage", () => {
   it("storage to contain all fields", () => {
-    expect(Object.keys(registry)).toHaveLength(41);
+    expect(Object.keys(registry)).toHaveLength(42);
   });
 
   it("storage to initialize with correct data", () => {
+    expect(registry.simulator).toBeNull();
     expect(registry.actor).toBeNull();
     expect(registry.activeSpeaker).toBeNull();
     expect(registry.activeSmartTerrainId).toBeNull();

--- a/src/engine/core/database/registry.ts
+++ b/src/engine/core/database/registry.ts
@@ -21,6 +21,7 @@ import type { TConditionList } from "@/engine/core/utils/ini/ini_types";
 import type { ERelation } from "@/engine/core/utils/relation";
 import { storyNames, TStoryName } from "@/engine/lib/constants/story_names";
 import type {
+  AlifeSimulator,
   ClientObject,
   EScheme,
   IniFile,
@@ -36,6 +37,10 @@ import type {
  * Stores up-to-date game state.
  */
 export const registry = {
+  /**
+   * Current simulator, injected on game start.
+   */
+  simulator: null as unknown as AlifeSimulator,
   /**
    * Current actor, injected on game start.
    */

--- a/src/engine/core/database/simulation.test.ts
+++ b/src/engine/core/database/simulation.test.ts
@@ -1,10 +1,22 @@
-import { beforeEach, describe, it } from "@jest/globals";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { alife } from "xray16";
 
 import { registry } from "@/engine/core/database/registry";
+import { registerSimulator } from "@/engine/core/database/simulation";
+import { AlifeSimulator } from "@/engine/lib/types";
 
 describe("'simulation' module of the database", () => {
   beforeEach(() => {
+    registry.simulator = null as unknown as AlifeSimulator;
     registry.objects = new LuaTable();
+  });
+
+  it("registerSimulator should correctly register simulator", () => {
+    expect(registry.simulator).toBeNull();
+
+    registerSimulator();
+
+    expect(registry.simulator).toBe(alife());
   });
 
   it.todo("should correctly register simulation objects");

--- a/src/engine/core/database/simulation.ts
+++ b/src/engine/core/database/simulation.ts
@@ -1,4 +1,4 @@
-import { clsid } from "xray16";
+import { alife, clsid } from "xray16";
 
 import { SIMULATION_OBJECTS_PROPS_LTX } from "@/engine/core/database/ini_registry";
 import { registry } from "@/engine/core/database/registry";
@@ -7,6 +7,13 @@ import { parseConditionsList } from "@/engine/core/utils/ini/ini_parse";
 import { isSquad } from "@/engine/core/utils/object/object_class";
 import { ACTOR, DEFAULT } from "@/engine/lib/constants/words";
 import { TCount, TSection } from "@/engine/lib/types";
+
+/**
+ * Register simulator instance in the registry.
+ */
+export function registerSimulator(): void {
+  registry.simulator = alife();
+}
 
 /**
  * Register simulation object in registries for participation in game events.

--- a/src/engine/core/database/types.ts
+++ b/src/engine/core/database/types.ts
@@ -179,7 +179,7 @@ export interface IRegistryObjectState extends Record<EScheme, Optional<IBaseSche
   /**
    * todo;
    */
-  enemy_id: Optional<TNumberId>;
+  enemyId: Optional<TNumberId>;
   /**
    * todo;
    */

--- a/src/engine/core/managers/debug/DebugManager.ts
+++ b/src/engine/core/managers/debug/DebugManager.ts
@@ -201,8 +201,8 @@ export class DebugManager extends AbstractManager {
     logger.info("Activation game time:", gameTimeToString(state.activationGameTime));
     logger.info("Portable store:", toJSON(state.portableStore));
     logger.info("State overrides:", toJSON(state.overrides));
-    logger.info("Enemy id:", state.enemy_id);
-    logger.info("Enemy name:", state.enemy_id ? alife().object(state.enemy_id)?.name() : NIL);
+    logger.info("Enemy id:", state.enemyId);
+    logger.info("Enemy name:", state.enemyId ? alife().object(state.enemyId)?.name() : NIL);
     logger.info("Script combat type:", state.script_combat_type);
     logger.info("Registered camp:", state.camp || "none");
 

--- a/src/engine/core/objects/ai/scheme/AbstractScheme.ts
+++ b/src/engine/core/objects/ai/scheme/AbstractScheme.ts
@@ -47,6 +47,11 @@ export abstract class AbstractScheme {
 
   /**
    * Assign some scheme state to an object and prepare shared constants in it in a correct way.
+   * Initializes base state in object registry.
+   *
+   * todo;
+   *
+   * @returns base scheme state for provided `scheme`
    */
   protected static assign<T extends IBaseSchemeState>(
     object: ClientObject,

--- a/src/engine/core/objects/binders/creature/StalkerBinder.test.ts
+++ b/src/engine/core/objects/binders/creature/StalkerBinder.test.ts
@@ -75,6 +75,7 @@ describe("StalkerBinder class", () => {
       EPacketDataType.STRING,
       EPacketDataType.STRING,
       EPacketDataType.STRING,
+      EPacketDataType.STRING,
       EPacketDataType.I32,
       EPacketDataType.U8,
       EPacketDataType.U8,
@@ -88,6 +89,7 @@ describe("StalkerBinder class", () => {
       EPacketDataType.U16,
     ]);
     expect(netProcessor.dataList).toEqual([
+      "save_from_StalkerBinder",
       "job_ini.ltx",
       "ini.ltx",
       "logic",
@@ -103,7 +105,7 @@ describe("StalkerBinder class", () => {
       500,
       0,
       14,
-      15,
+      16,
     ]);
 
     binder.load(mockNetReader(netProcessor));

--- a/src/engine/core/objects/binders/creature/StalkerBinder.test.ts
+++ b/src/engine/core/objects/binders/creature/StalkerBinder.test.ts
@@ -1,6 +1,26 @@
-import { describe, it } from "@jest/globals";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import { IRegistryObjectState, registerObject, registry } from "@/engine/core/database";
+import { DialogManager } from "@/engine/core/managers/dialogs";
+import { GlobalSoundManager } from "@/engine/core/managers/sounds";
+import { TradeManager } from "@/engine/core/managers/trade";
+import { StalkerBinder } from "@/engine/core/objects/binders";
+import { ClientObject } from "@/engine/lib/types";
+import {
+  EPacketDataType,
+  mockClientGameObject,
+  MockCTime,
+  mockNetPacket,
+  MockNetProcessor,
+  mockNetReader,
+} from "@/fixtures/xray";
 
 describe("StalkerBinder class", () => {
+  beforeEach(() => {
+    registry.managers = new LuaTable();
+    registry.objects = new LuaTable();
+  });
+
   it.todo("should correctly initialize");
 
   it.todo("should correctly initialize info portions");
@@ -11,7 +31,90 @@ describe("StalkerBinder class", () => {
 
   it.todo("should correctly handle update event");
 
-  it.todo("should correctly handle save/load");
+  it("should correctly handle save/load", () => {
+    const tradeManager: TradeManager = TradeManager.getInstance();
+    const globalSoundManager: GlobalSoundManager = GlobalSoundManager.getInstance();
+    const dialogManager: DialogManager = DialogManager.getInstance();
+
+    jest.spyOn(tradeManager, "saveObjectState").mockImplementation(jest.fn());
+    jest.spyOn(tradeManager, "loadObjectState").mockImplementation(jest.fn());
+    jest.spyOn(globalSoundManager, "saveObject").mockImplementation(jest.fn());
+    jest.spyOn(globalSoundManager, "loadObject").mockImplementation(jest.fn());
+    jest.spyOn(dialogManager, "saveObjectDialogs").mockImplementation(jest.fn());
+    jest.spyOn(dialogManager, "loadObjectDialogs").mockImplementation(jest.fn());
+
+    jest.spyOn(Date, "now").mockImplementationOnce(() => 7000);
+
+    const object: ClientObject = mockClientGameObject();
+    const binder: StalkerBinder = new StalkerBinder(object);
+    const netProcessor: MockNetProcessor = new MockNetProcessor();
+
+    registerObject(object);
+
+    binder.reinit();
+
+    const state: IRegistryObjectState = registry.objects.get(object.id());
+
+    state.activationTime = 5000;
+    state.activationGameTime = MockCTime.mock(2012, 6, 12, 20, 15, 30, 500);
+    state.jobIni = "job_ini.ltx";
+    state.iniFilename = "ini.ltx";
+    state.sectionLogic = "logic";
+    state.activeSection = "scheme@section";
+    state.smartTerrainName = "some_smart";
+
+    binder.save(mockNetPacket(netProcessor));
+
+    expect(tradeManager.saveObjectState).toHaveBeenCalledWith(netProcessor, object);
+    expect(globalSoundManager.saveObject).toHaveBeenCalledWith(netProcessor, object);
+    expect(dialogManager.saveObjectDialogs).toHaveBeenCalledWith(netProcessor, object);
+
+    expect(netProcessor.writeDataOrder).toEqual([
+      EPacketDataType.STRING,
+      EPacketDataType.STRING,
+      EPacketDataType.STRING,
+      EPacketDataType.STRING,
+      EPacketDataType.STRING,
+      EPacketDataType.I32,
+      EPacketDataType.U8,
+      EPacketDataType.U8,
+      EPacketDataType.U8,
+      EPacketDataType.U8,
+      EPacketDataType.U8,
+      EPacketDataType.U8,
+      EPacketDataType.U16,
+      EPacketDataType.U32,
+      EPacketDataType.U16,
+      EPacketDataType.U16,
+    ]);
+    expect(netProcessor.dataList).toEqual([
+      "job_ini.ltx",
+      "ini.ltx",
+      "logic",
+      "scheme@section",
+      "some_smart",
+      -2000,
+      12,
+      6,
+      12,
+      20,
+      15,
+      30,
+      500,
+      0,
+      14,
+      15,
+    ]);
+
+    binder.load(mockNetReader(netProcessor));
+
+    expect(tradeManager.loadObjectState).toHaveBeenCalledWith(netProcessor, object);
+    expect(globalSoundManager.loadObject).toHaveBeenCalledWith(netProcessor, object);
+    expect(dialogManager.loadObjectDialogs).toHaveBeenCalledWith(netProcessor, object);
+
+    expect(netProcessor.readDataOrder).toEqual(netProcessor.writeDataOrder);
+    expect(netProcessor.dataList).toHaveLength(0);
+  });
 
   it.todo("should correctly handle death event");
 

--- a/src/engine/core/objects/binders/creature/StalkerBinder.ts
+++ b/src/engine/core/objects/binders/creature/StalkerBinder.ts
@@ -42,7 +42,7 @@ import { SmartTerrain } from "@/engine/core/objects/server/smart_terrain/SmartTe
 import { SchemeHear } from "@/engine/core/schemes/shared/hear/SchemeHear";
 import { SchemeCombat } from "@/engine/core/schemes/stalker/combat/SchemeCombat";
 import { PostCombatIdle } from "@/engine/core/schemes/stalker/combat_idle/PostCombatIdle";
-import { activateMeetWithObject, updateObjectInteractionAvailability } from "@/engine/core/schemes/stalker/meet/utils";
+import { activateMeetWithObject, updateObjectMeetAvailability } from "@/engine/core/schemes/stalker/meet/utils";
 import { SchemeReachTask } from "@/engine/core/schemes/stalker/reach_task/SchemeReachTask";
 import { ISchemeWoundedState } from "@/engine/core/schemes/stalker/wounded";
 import { assert } from "@/engine/core/utils/assertion";
@@ -118,6 +118,11 @@ export class StalkerBinder extends object_binder {
 
     setupStalkerStatePlanner(this.state.stateManager.planner, this.state.stateManager);
     setupStalkerMotivationPlanner(this.object.motivation_action_manager(), this.state.stateManager);
+
+    // Expose state planner for in-game debugging tools.
+    if (this.object.debug_planner !== null) {
+      this.object.debug_planner(this.state.stateManager.planner);
+    }
   }
 
   public override net_spawn(object: ServerCreatureObject): boolean {
@@ -286,7 +291,7 @@ export class StalkerBinder extends object_binder {
 
     if (isObjectAlive) {
       GlobalSoundManager.getInstance().update(object.id());
-      updateObjectInteractionAvailability(object);
+      updateObjectMeetAvailability(object);
       initializeObjectInvulnerability(this.object);
     }
 

--- a/src/engine/core/objects/binders/creature/StalkerBinder.ts
+++ b/src/engine/core/objects/binders/creature/StalkerBinder.ts
@@ -3,7 +3,6 @@ import {
   alife,
   callback,
   game_graph,
-  ini_file,
   level,
   LuabindClass,
   object_binder,
@@ -14,7 +13,6 @@ import {
 import {
   closeLoadMarker,
   closeSaveMarker,
-  DUMMY_LTX,
   IBaseSchemeState,
   IRegistryObjectState,
   loadObjectLogic,
@@ -25,7 +23,6 @@ import {
   registry,
   resetObject,
   saveObjectLogic,
-  SYSTEM_INI,
   unregisterHelicopterEnemy,
   unregisterStalker,
 } from "@/engine/core/database";
@@ -52,7 +49,14 @@ import { assert } from "@/engine/core/utils/assertion";
 import { pickSectionFromCondList, readIniString, TConditionList } from "@/engine/core/utils/ini";
 import { ISmartTerrainJobDescriptor } from "@/engine/core/utils/job";
 import { LuaLogger } from "@/engine/core/utils/logging";
-import { getObjectCommunity, getObjectSquad, isUndergroundLevel } from "@/engine/core/utils/object";
+import {
+  getObjectCommunity,
+  getObjectSquad,
+  getObjectStalkerIni,
+  isUndergroundLevel,
+  setupObjectInfoPortions,
+  setupObjectStalkerVisual,
+} from "@/engine/core/utils/object";
 import { ERelation, setClientObjectRelation, setObjectSympathy } from "@/engine/core/utils/relation";
 import {
   emitSchemeEvent,
@@ -72,7 +76,6 @@ import {
   EClientObjectRelation,
   EScheme,
   ESchemeEvent,
-  IniFile,
   NetPacket,
   Optional,
   Reader,
@@ -118,17 +121,16 @@ export class StalkerBinder extends object_binder {
   }
 
   public override net_spawn(object: ServerCreatureObject): boolean {
-    const objectId: TNumberId = this.object.id();
-    const actor: ClientObject = registry.actor;
-    const visual: TName = readIniString(SYSTEM_INI, this.object.section(), "set_visual", false, "");
-
-    if (visual !== null && visual !== "") {
-      this.object.set_visual_name(visual === "actor_visual" ? actor.get_visual_name() : visual);
-    }
+    setupObjectStalkerVisual(this.object);
 
     if (!super.net_spawn(object)) {
       return false;
     }
+
+    const objectId: TNumberId = this.object.id();
+    const actor: ClientObject = registry.actor;
+
+    logger.info("Net spawn:", object.name());
 
     registerStalker(this);
 
@@ -137,19 +139,7 @@ export class StalkerBinder extends object_binder {
     this.object.apply_loophole_direction_distance(1.0);
 
     if (!this.isLoaded) {
-      const spawnIni: Optional<IniFile> = this.object.spawn_ini();
-
-      const stalkerIniFilename: Optional<TName> =
-        spawnIni === null ? null : readIniString(spawnIni, "logic", "cfg", false, "");
-      let stalkerIni: Optional<IniFile> = null;
-
-      if (stalkerIniFilename !== null) {
-        stalkerIni = new ini_file(stalkerIniFilename);
-      } else {
-        stalkerIni = this.object.spawn_ini() || DUMMY_LTX;
-      }
-
-      this.initializeInfoPortions(stalkerIni, null);
+      setupObjectInfoPortions(this.object, getObjectStalkerIni(this.object));
     }
 
     if (!this.object.alive()) {
@@ -161,7 +151,7 @@ export class StalkerBinder extends object_binder {
 
     const relation: Optional<ERelation> = registry.goodwill.relations.get(objectId);
 
-    if (relation !== null && actor) {
+    if (relation !== null) {
       setClientObjectRelation(this.object, actor, relation);
     }
 
@@ -174,11 +164,10 @@ export class StalkerBinder extends object_binder {
     this.helicopterEnemyIndex = registerHelicopterEnemy(this.object);
 
     GlobalSoundManager.initializeObjectSounds(this.object);
-
     SchemeReachTask.addReachTaskSchemeAction(this.object);
 
     // todo: Why? Already same ref in parameter?
-    const serverObject: Optional<ServerHumanObject> = alife().object(objectId);
+    const serverObject: Optional<ServerHumanObject> = registry.simulator.object(objectId);
 
     if (serverObject !== null) {
       if (registry.spawnedVertexes.get(serverObject.id) !== null) {
@@ -189,7 +178,7 @@ export class StalkerBinder extends object_binder {
           level.vertex_position(registry.offlineObjects.get(serverObject.id).levelVertexId as TNumberId)
         );
       } else if (serverObject.m_smart_terrain_id !== MAX_U16) {
-        const smartTerrain: SmartTerrain = alife().object<SmartTerrain>(serverObject.m_smart_terrain_id)!;
+        const smartTerrain: SmartTerrain = registry.simulator.object<SmartTerrain>(serverObject.m_smart_terrain_id)!;
 
         if (smartTerrain.arrivingObjects.get(serverObject.id) === null) {
           const job: Optional<ISmartTerrainJobDescriptor> = smartTerrain.objectJobDescriptors.get(serverObject.id)?.job;
@@ -209,11 +198,9 @@ export class StalkerBinder extends object_binder {
 
     setupObjectSmartJobsAndLogicOnSpawn(this.object, this.state, ESchemeType.STALKER, this.isLoaded);
 
-    if (getObjectCommunity(this.object) !== communities.zombied) {
-      PostCombatIdle.addPostCombatIdleWait(this.object);
-    }
+    PostCombatIdle.addPostCombatIdleWait(this.object);
 
-    this.object.group_throw_time_interval(2_000);
+    this.object.group_throw_time_interval(2_000); // todo: Interval to check danger from group objects?
 
     return true;
   }
@@ -245,7 +232,7 @@ export class StalkerBinder extends object_binder {
 
     if (registry.offlineObjects.get(objectId) !== null) {
       registry.offlineObjects.get(objectId).levelVertexId = this.object.level_vertex_id();
-      registry.offlineObjects.get(objectId).activeSection = registry.objects.get(objectId).activeSection as TSection;
+      registry.offlineObjects.get(objectId).activeSection = state.activeSection as TSection;
     }
 
     unregisterStalker(this);
@@ -305,10 +292,8 @@ export class StalkerBinder extends object_binder {
 
     const squad = getObjectSquad(this.object);
 
-    if (squad !== null) {
-      if (squad.commander_id() === this.object.id()) {
-        squad.update();
-      }
+    if (squad !== null && squad.commander_id() === this.object.id()) {
+      squad.update();
     }
 
     if (!isObjectAlive) {
@@ -399,6 +384,7 @@ export class StalkerBinder extends object_binder {
 
     super.save(packet);
     saveObjectLogic(this.object, packet);
+
     TradeManager.getInstance().saveObjectState(packet, this.object);
     GlobalSoundManager.getInstance().saveObject(packet, this.object);
     DialogManager.getInstance().saveObjectDialogs(packet, this.object);
@@ -413,25 +399,12 @@ export class StalkerBinder extends object_binder {
 
     super.load(reader);
     loadObjectLogic(this.object, reader);
+
     TradeManager.getInstance().loadObjectState(reader, this.object);
     GlobalSoundManager.getInstance().loadObject(reader, this.object);
     DialogManager.getInstance().loadObjectDialogs(reader, this.object);
 
     closeLoadMarker(reader, StalkerBinder.__name);
-  }
-
-  public initializeInfoPortions(characterIni: IniFile, knownInfoSection: Optional<TSection>): void {
-    knownInfoSection = knownInfoSection === null ? "known_info" : knownInfoSection;
-
-    if (characterIni.section_exist(knownInfoSection)) {
-      const knownInfosCount: TCount = characterIni.line_count(knownInfoSection);
-
-      for (const it of $range(0, knownInfosCount - 1)) {
-        const [result, infoPortion, value] = characterIni.r_line(knownInfoSection, it, "", "");
-
-        this.object.give_info_portion(infoPortion);
-      }
-    }
   }
 
   /**
@@ -465,6 +438,7 @@ export class StalkerBinder extends object_binder {
     soundPosition: Vector,
     soundPower: TRate
   ): void {
+    // Dont handle own sounds.
     if (whoId === target.id()) {
       return;
     }
@@ -486,9 +460,7 @@ export class StalkerBinder extends object_binder {
 
     MapDisplayManager.getInstance().removeObjectMapSpot(this.object, state);
 
-    const knownInfo: Optional<TName> = readIniString(state.ini!, state.sectionLogic, "known_info", false, "", null);
-
-    this.initializeInfoPortions(state.ini!, knownInfo);
+    setupObjectInfoPortions(this.object, state.ini, readIniString(state.ini, state.sectionLogic, "known_info", false));
 
     if (this.state.stateManager !== null) {
       this.state.stateManager!.animation.setState(null, true);
@@ -517,9 +489,7 @@ export class StalkerBinder extends object_binder {
     if (actor_stats.remove_from_ranking !== null) {
       const community: TCommunity = getObjectCommunity(this.object);
 
-      if (community === communities.zombied || community === communities.monolith) {
-        // placeholder
-      } else {
+      if (community !== communities.zombied && community !== communities.monolith) {
         actor_stats.remove_from_ranking(this.object.id());
       }
     }
@@ -650,8 +620,8 @@ export function updateStalkerLogic(object: ClientObject): void {
   const combatState: IBaseSchemeState = state.combat!;
 
   if (state !== null && state.activeScheme !== null && object.alive()) {
-    let switched: boolean = false;
     const manager: ActionPlanner = object.motivation_action_manager();
+    let switched: boolean = false;
 
     if (manager.initialized() && manager.current_action_id() === EActionId.COMBAT) {
       const overrides: Optional<AnyObject> = state.overrides;

--- a/src/engine/core/objects/sounds/playable_sounds/NpcSound.ts
+++ b/src/engine/core/objects/sounds/playable_sounds/NpcSound.ts
@@ -255,7 +255,7 @@ export class NpcSound extends AbstractPlayableSound {
       return false;
     }
 
-    logger.info("Play NPC sound for:", object.name(), faction, point, message, "#");
+    logger.format("Play NPC sound for: '%s', '%s', '%s', '%s'", object.name(), faction, point, message);
 
     this.playingStartedAt = null;
 

--- a/src/engine/core/schemes/stalker/combat_idle/PostCombatIdle.ts
+++ b/src/engine/core/schemes/stalker/combat_idle/PostCombatIdle.ts
@@ -6,6 +6,8 @@ import { ActionPostCombatIdleWait } from "@/engine/core/schemes/stalker/combat_i
 import { EvaluatorHasEnemy } from "@/engine/core/schemes/stalker/combat_idle/evaluators";
 import { ISchemePostCombatIdleState } from "@/engine/core/schemes/stalker/combat_idle/ISchemePostCombatIdleState";
 import { LuaLogger } from "@/engine/core/utils/logging";
+import { getObjectCommunity } from "@/engine/core/utils/object";
+import { communities } from "@/engine/lib/constants/communities";
 import { ActionBase, ActionPlanner, ClientObject } from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename);
@@ -17,9 +19,14 @@ const logger: LuaLogger = new LuaLogger($filename);
 export class PostCombatIdle {
   /**
    * todo: Description.
+   * todo: Generic idle
    */
   public static addPostCombatIdleWait(object: ClientObject): void {
     // logger.info("Add post-combat idle for:", object.name());
+
+    if (getObjectCommunity(object) === communities.zombied) {
+      return;
+    }
 
     const actionPlanner: ActionPlanner = object.motivation_action_manager();
     const combatAction: ActionBase = actionPlanner.action(EActionId.COMBAT);

--- a/src/engine/core/schemes/stalker/corpse_detection/utils/loot.test.ts
+++ b/src/engine/core/schemes/stalker/corpse_detection/utils/loot.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 
 import { IRegistryObjectState, registerObject } from "@/engine/core/database";
 import { GlobalSoundManager } from "@/engine/core/managers/sounds/GlobalSoundManager";
@@ -30,7 +30,7 @@ describe("loot utils for corpse_detection scheme", () => {
 
     const state: IRegistryObjectState = registerObject(object);
 
-    jest.spyOn(soundManager, "playSound").mockImplementation();
+    jest.spyOn(soundManager, "playSound").mockImplementation(() => null);
     jest.spyOn(math, "random").mockImplementation(() => 0);
     loadSchemeImplementation(SchemeCorpseDetection);
 

--- a/src/engine/core/schemes/stalker/meet/SchemeMeet.ts
+++ b/src/engine/core/schemes/stalker/meet/SchemeMeet.ts
@@ -13,7 +13,7 @@ import { LuaLogger } from "@/engine/core/utils/logging";
 import { NIL } from "@/engine/lib/constants/words";
 import { ActionPlanner, ClientObject, EScheme, ESchemeType, IniFile, TSection } from "@/engine/lib/types";
 
-const logger: LuaLogger = new LuaLogger($filename);
+const logger: LuaLogger = new LuaLogger($filename, { file: "meet" });
 
 /**
  * Scheme describing logics of `meet` state.
@@ -65,8 +65,10 @@ export class SchemeMeet extends AbstractScheme {
     actionMeetWait.add_effect(new world_property(EEvaluatorId.IS_MEET_CONTACT, false));
     planner.add_action(EActionId.MEET_WAITING_ACTIVITY, actionMeetWait);
 
+    // Block alife when meeting.
     planner.action(EActionId.ALIFE).add_precondition(new world_property(EEvaluatorId.IS_MEET_CONTACT, false));
 
+    // Block state reset for alife when meeting.
     planner
       .action(EActionId.STATE_TO_IDLE_ALIFE)
       .add_precondition(new world_property(EEvaluatorId.IS_MEET_CONTACT, false));
@@ -88,8 +90,8 @@ export class SchemeMeet extends AbstractScheme {
     // Read meet configuration from current logics section or from provided section, if it is valid.
     const meetSection: TSection =
       scheme === null || scheme === NIL
-        ? readIniString(state.ini, state.sectionLogic, SchemeMeet.SCHEME_SECTION, false, "")
-        : readIniString(state.ini, section, SchemeMeet.SCHEME_SECTION, false, "");
+        ? readIniString(state.ini, state.sectionLogic, SchemeMeet.SCHEME_SECTION, false)
+        : readIniString(state.ini, section, SchemeMeet.SCHEME_SECTION, false);
 
     initializeMeetScheme(object, state.ini, meetSection, state.meet as ISchemeMeetState);
   }

--- a/src/engine/core/schemes/stalker/meet/actions/ActionMeetWait.ts
+++ b/src/engine/core/schemes/stalker/meet/actions/ActionMeetWait.ts
@@ -3,7 +3,7 @@ import { action_base, LuabindClass } from "xray16";
 import { ISchemeMeetState } from "@/engine/core/schemes/stalker/meet";
 import { LuaLogger } from "@/engine/core/utils/logging";
 
-const logger: LuaLogger = new LuaLogger($filename);
+const logger: LuaLogger = new LuaLogger($filename, { file: "meet" });
 
 /**
  * Action to wait for actor to speak, when actor is close.
@@ -44,6 +44,6 @@ export class ActionMeetWait extends action_base {
   public override execute(): void {
     super.execute();
 
-    this.state.meetManager.activateMeetState();
+    this.state.meetManager.execute();
   }
 }

--- a/src/engine/core/schemes/stalker/meet/evaluators/EvaluatorContact.ts
+++ b/src/engine/core/schemes/stalker/meet/evaluators/EvaluatorContact.ts
@@ -8,7 +8,7 @@ import { isObjectWounded } from "@/engine/core/utils/object";
 import { FALSE } from "@/engine/lib/constants/words";
 import { ActionPlanner, Optional } from "@/engine/lib/types";
 
-const logger: LuaLogger = new LuaLogger($filename);
+const logger: LuaLogger = new LuaLogger($filename, { file: "meet" });
 
 /**
  * Evaluator to check if object is ready to communicate.

--- a/src/engine/core/schemes/stalker/meet/utils/meet_defaults.test.ts
+++ b/src/engine/core/schemes/stalker/meet/utils/meet_defaults.test.ts
@@ -34,8 +34,7 @@ describe("meet scheme defaults", () => {
       isBreakAllowed: TRUE,
       closeAnimation: "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_has_weapon} threat_na, talk_default",
       closeDistance: "{=is_wounded} 0, {!is_squad_commander} 0, 3",
-      closeSoundBye:
-        "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} nil, meet_hello",
+      closeSoundBye: NIL,
       close_snd_distance: "{=is_wounded} 0, {!is_squad_commander} 0, 3",
       closeSoundHello:
         "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} meet_hide_weapon," +
@@ -50,7 +49,7 @@ describe("meet scheme defaults", () => {
       isMeetOnTalking: TRUE,
       useSound:
         "{=is_wounded} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_enemy} nil," +
-        " {=has_enemy} meet_use_no_fight, {=actor_has_weapon} meet_use_no_weapon, {!dist_to_actor_le(3)} nil",
+        " {=has_enemy} meet_use_no_fight, {=actor_has_weapon} meet_use_no_weapon, nil",
       isTradeEnabled: TRUE,
       use:
         "{=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false," +

--- a/src/engine/core/schemes/stalker/meet/utils/meet_defaults.ts
+++ b/src/engine/core/schemes/stalker/meet/utils/meet_defaults.ts
@@ -33,8 +33,7 @@ export const meetNeutralDefaults = {
   isBreakAllowed: TRUE,
   closeAnimation: "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_has_weapon} threat_na, talk_default",
   closeDistance: "{=is_wounded} 0, {!is_squad_commander} 0, 3",
-  closeSoundBye:
-    "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} nil, meet_hello",
+  closeSoundBye: NIL,
   close_snd_distance: "{=is_wounded} 0, {!is_squad_commander} 0, 3",
   closeSoundHello:
     "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil," +
@@ -47,10 +46,10 @@ export const meetNeutralDefaults = {
   farVictim: NIL,
   meetDialog: NIL,
   isMeetOnTalking: TRUE,
+  isTradeEnabled: TRUE,
   useSound:
     "{=is_wounded} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_enemy} nil," +
-    " {=has_enemy} meet_use_no_fight, {=actor_has_weapon} meet_use_no_weapon, {!dist_to_actor_le(3)} nil",
-  isTradeEnabled: TRUE,
+    " {=has_enemy} meet_use_no_fight, {=actor_has_weapon} meet_use_no_weapon, nil",
   use:
     "{=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false," +
     " {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false",

--- a/src/engine/core/schemes/stalker/meet/utils/meet_handling.ts
+++ b/src/engine/core/schemes/stalker/meet/utils/meet_handling.ts
@@ -15,12 +15,12 @@ import { getObjectsRelationSafe } from "@/engine/core/utils/relation";
 import { FALSE, NIL, TRUE } from "@/engine/lib/constants/words";
 import { ClientObject, EClientObjectRelation, EScheme, Optional, TName } from "@/engine/lib/types";
 
-const logger: LuaLogger = new LuaLogger($filename);
+const logger: LuaLogger = new LuaLogger($filename, { file: "meet" });
 
 /**
  * todo: Description.
  */
-export function updateObjectInteractionAvailability(object: ClientObject): void {
+export function updateObjectMeetAvailability(object: ClientObject): void {
   if (isObjectWounded(object.id())) {
     if (object.relation(registry.actor) === EClientObjectRelation.ENEMY) {
       object.disable_talk();
@@ -58,6 +58,8 @@ export function updateObjectInteractionAvailability(object: ClientObject): void 
 }
 
 /**
+ * Handle meet interaction with object.
+ *
  * todo: Description.
  */
 export function activateMeetWithObject(object: ClientObject): void {
@@ -71,12 +73,13 @@ export function activateMeetWithObject(object: ClientObject): void {
     return;
   }
 
-  logger.info("Activate meet interaction:", object.name());
+  logger.format("Activate meet interaction: '%s'", object.name());
 
   const actor: ClientObject = registry.actor;
   const sound: Optional<TName> = pickSectionFromCondList(actor, object, state.useSound);
 
   if (tostring(sound) !== NIL) {
+    logger.format("Play meet sound: '%s' - '%s'", object.name(), sound);
     GlobalSoundManager.getInstance().playSound(object.id(), sound);
   }
 

--- a/src/engine/core/schemes/stalker/reach_task/SchemeReachTask.ts
+++ b/src/engine/core/schemes/stalker/reach_task/SchemeReachTask.ts
@@ -46,6 +46,7 @@ export class SchemeReachTask extends AbstractScheme {
 
   /**
    * todo: Description.
+   * todo: generic init method?
    */
   public static addReachTaskSchemeAction(object: ClientObject): void {
     const actionPlanner: ActionPlanner = object.motivation_action_manager();

--- a/src/engine/core/ui/menu/MainMenu.ts
+++ b/src/engine/core/ui/menu/MainMenu.ts
@@ -189,6 +189,8 @@ export class MainMenu extends CUIScriptWnd {
    * Clicked load last save.
    */
   public onLoadLastSaveButtonClick(): void {
+    logger.info("Load last save click");
+
     if (alife() === null) {
       return loadLastGameSave();
     }

--- a/src/engine/core/utils/ini/ini_parse.ts
+++ b/src/engine/core/utils/ini/ini_parse.ts
@@ -486,7 +486,7 @@ export function parseAllSectionToTable<T = string>(ini: IniFile, section: TSecti
  * @param value - value to check
  * @returns value or null in case of `nil` string
  */
-export function parseStringOptional<T extends StringOptional>(value: T): Optional<T> {
+export function parseStringOptional<T extends StringOptional>(value: Optional<T>): Optional<T> {
   return value === NIL ? null : value;
 }
 

--- a/src/engine/core/utils/job/job_create/__test__/job_create.default.ltx
+++ b/src/engine/core/utils/job/job_create/__test__/job_create.default.ltx
@@ -2,14 +2,14 @@
 close_distance = {=is_wounded} 0, 2
 close_anim = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_has_weapon} threat_na, talk_default
 close_snd_hello = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} meet_hide_weapon, meet_hello
-close_snd_bye = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} nil, meet_hello
+close_snd_bye = nil
 close_victim = {=is_wounded} nil, {!is_squad_commander} nil, actor
 far_distance = 0
 far_anim = nil
 far_snd = nil
 far_victim = nil
 use = {=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false, {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false
-snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, {=dist_to_actor_le(3)} meet_use_no_default, nil
+snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, nil
 meet_dialog = nil
 abuse = {=has_enemy} false, true
 trade_enable = true
@@ -17,16 +17,16 @@ allow_break = true
 use_text = nil
 [meet@generic_animpoint]
 close_distance = 0
-close_anim = {!is_squad_commander} nil, nil
-close_snd_hello = {!is_squad_commander} nil, nil
-close_snd_bye = {!is_squad_commander} nil, nil
-close_victim = {!is_squad_commander} nil, nil
+close_anim = nil
+close_snd_hello = nil
+close_snd_bye = nil
+close_victim = nil
 far_distance = 0
 far_anim = nil
 far_snd = nil
 far_victim = nil
 use = {=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false, {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false
-snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, {=dist_to_actor_le(3)} meet_use_no_default, nil
+snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, nil
 meet_dialog = nil
 abuse = {=has_enemy} false, true
 trade_enable = true

--- a/src/engine/core/utils/job/job_create/__test__/job_create.empty.ltx
+++ b/src/engine/core/utils/job/job_create/__test__/job_create.empty.ltx
@@ -2,14 +2,14 @@
 close_distance = {=is_wounded} 0, 2
 close_anim = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_has_weapon} threat_na, talk_default
 close_snd_hello = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} meet_hide_weapon, meet_hello
-close_snd_bye = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} nil, meet_hello
+close_snd_bye = nil
 close_victim = {=is_wounded} nil, {!is_squad_commander} nil, actor
 far_distance = 0
 far_anim = nil
 far_snd = nil
 far_victim = nil
 use = {=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false, {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false
-snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, {=dist_to_actor_le(3)} meet_use_no_default, nil
+snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, nil
 meet_dialog = nil
 abuse = {=has_enemy} false, true
 trade_enable = true
@@ -17,16 +17,16 @@ allow_break = true
 use_text = nil
 [meet@generic_animpoint]
 close_distance = 0
-close_anim = {!is_squad_commander} nil, nil
-close_snd_hello = {!is_squad_commander} nil, nil
-close_snd_bye = {!is_squad_commander} nil, nil
-close_victim = {!is_squad_commander} nil, nil
+close_anim = nil
+close_snd_hello = nil
+close_snd_bye = nil
+close_victim = nil
 far_distance = 0
 far_anim = nil
 far_snd = nil
 far_victim = nil
 use = {=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false, {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false
-snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, {=dist_to_actor_le(3)} meet_use_no_default, nil
+snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, nil
 meet_dialog = nil
 abuse = {=has_enemy} false, true
 trade_enable = true

--- a/src/engine/core/utils/job/job_create/__test__/job_create_stalker.default.ltx
+++ b/src/engine/core/utils/job/job_create/__test__/job_create_stalker.default.ltx
@@ -2,14 +2,14 @@
 close_distance = {=is_wounded} 0, 2
 close_anim = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_has_weapon} threat_na, talk_default
 close_snd_hello = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} meet_hide_weapon, meet_hello
-close_snd_bye = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} nil, meet_hello
+close_snd_bye = nil
 close_victim = {=is_wounded} nil, {!is_squad_commander} nil, actor
 far_distance = 0
 far_anim = nil
 far_snd = nil
 far_victim = nil
 use = {=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false, {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false
-snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, {=dist_to_actor_le(3)} meet_use_no_default, nil
+snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, nil
 meet_dialog = nil
 abuse = {=has_enemy} false, true
 trade_enable = true
@@ -17,16 +17,16 @@ allow_break = true
 use_text = nil
 [meet@generic_animpoint]
 close_distance = 0
-close_anim = {!is_squad_commander} nil, nil
-close_snd_hello = {!is_squad_commander} nil, nil
-close_snd_bye = {!is_squad_commander} nil, nil
-close_victim = {!is_squad_commander} nil, nil
+close_anim = nil
+close_snd_hello = nil
+close_snd_bye = nil
+close_victim = nil
 far_distance = 0
 far_anim = nil
 far_snd = nil
 far_victim = nil
 use = {=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false, {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false
-snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, {=dist_to_actor_le(3)} meet_use_no_default, nil
+snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, nil
 meet_dialog = nil
 abuse = {=has_enemy} false, true
 trade_enable = true

--- a/src/engine/core/utils/job/job_create/__test__/job_create_stalker.empty.ltx
+++ b/src/engine/core/utils/job/job_create/__test__/job_create_stalker.empty.ltx
@@ -2,14 +2,14 @@
 close_distance = {=is_wounded} 0, 2
 close_anim = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_has_weapon} threat_na, talk_default
 close_snd_hello = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} meet_hide_weapon, meet_hello
-close_snd_bye = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} nil, meet_hello
+close_snd_bye = nil
 close_victim = {=is_wounded} nil, {!is_squad_commander} nil, actor
 far_distance = 0
 far_anim = nil
 far_snd = nil
 far_victim = nil
 use = {=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false, {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false
-snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, {=dist_to_actor_le(3)} meet_use_no_default, nil
+snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, nil
 meet_dialog = nil
 abuse = {=has_enemy} false, true
 trade_enable = true
@@ -17,16 +17,16 @@ allow_break = true
 use_text = nil
 [meet@generic_animpoint]
 close_distance = 0
-close_anim = {!is_squad_commander} nil, nil
-close_snd_hello = {!is_squad_commander} nil, nil
-close_snd_bye = {!is_squad_commander} nil, nil
-close_victim = {!is_squad_commander} nil, nil
+close_anim = nil
+close_snd_hello = nil
+close_snd_bye = nil
+close_victim = nil
 far_distance = 0
 far_anim = nil
 far_snd = nil
 far_victim = nil
 use = {=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false, {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false
-snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, {=dist_to_actor_le(3)} meet_use_no_default, nil
+snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, nil
 meet_dialog = nil
 abuse = {=has_enemy} false, true
 trade_enable = true

--- a/src/engine/core/utils/job/job_create/job_create_stalker.ts
+++ b/src/engine/core/utils/job/job_create/job_create_stalker.ts
@@ -31,14 +31,14 @@ export function createStalkerJobs(
 close_distance = {=is_wounded} 0, 2
 close_anim = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_has_weapon} threat_na, talk_default
 close_snd_hello = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} meet_hide_weapon, meet_hello
-close_snd_bye = {=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} nil, meet_hello
+close_snd_bye = nil
 close_victim = {=is_wounded} nil, {!is_squad_commander} nil, actor
 far_distance = 0
 far_anim = nil
 far_snd = nil
 far_victim = nil
 use = {=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false, {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false
-snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, {=dist_to_actor_le(3)} meet_use_no_default, nil
+snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, nil
 meet_dialog = nil
 abuse = {=has_enemy} false, true
 trade_enable = true
@@ -46,16 +46,16 @@ allow_break = true
 use_text = nil
 [meet@generic_animpoint]
 close_distance = 0
-close_anim = {!is_squad_commander} nil, nil
-close_snd_hello = {!is_squad_commander} nil, nil
-close_snd_bye = {!is_squad_commander} nil, nil
-close_victim = {!is_squad_commander} nil, nil
+close_anim = nil
+close_snd_hello = nil
+close_snd_bye = nil
+close_victim = nil
 far_distance = 0
 far_anim = nil
 far_snd = nil
 far_victim = nil
 use = {=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false, {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false
-snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, {=dist_to_actor_le(3)} meet_use_no_default, nil
+snd_on_use = {=is_wounded} nil, {=actor_enemy} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_has_weapon} meet_use_no_weapon, {=has_enemy} meet_use_no_fight, nil
 meet_dialog = nil
 abuse = {=has_enemy} false, true
 trade_enable = true

--- a/src/engine/core/utils/object/index.ts
+++ b/src/engine/core/utils/object/index.ts
@@ -12,6 +12,7 @@ export * from "@/engine/core/utils/object/object_loot";
 export * from "@/engine/core/utils/object/object_meeting";
 export * from "@/engine/core/utils/object/object_section";
 export * from "@/engine/core/utils/object/object_set";
+export * from "@/engine/core/utils/object/object_setup";
 export * from "@/engine/core/utils/object/object_smart_cover";
 export * from "@/engine/core/utils/object/object_sound";
 export * from "@/engine/core/utils/object/object_spawn";

--- a/src/engine/core/utils/object/object_action.test.ts
+++ b/src/engine/core/utils/object/object_action.test.ts
@@ -15,7 +15,7 @@ describe("object_action utils", () => {
     registry.managers = new LuaTable();
   });
 
-  it("'objectPunchActor' should correctly punch actor and force weapon drop based", () => {
+  it("objectPunchActor should correctly punch actor", () => {
     const ak74: ClientObject = mockClientGameObject({ sectionOverride: "wpn_ak74" });
     const actor: ClientObject = mockActorClientGameObject({
       active_item: () => actor.object(ak74.section()),
@@ -29,65 +29,27 @@ describe("object_action utils", () => {
     jest.spyOn(actor.position(), "distance_to_sqr").mockImplementation(() => 4.1);
     jest.spyOn(ActorInputManager.getInstance(), "setInactiveInputTime").mockImplementation(() => {});
 
+    // Too far.
     objectPunchActor(object);
 
     expect(level.add_cam_effector).not.toHaveBeenCalled();
     expect(ActorInputManager.getInstance().setInactiveInputTime).not.toHaveBeenCalled();
-    expect(actor.drop_item).not.toHaveBeenCalled();
-    expect(actor.object(ak74.section())).toBe(ak74);
 
     jest
       .spyOn(actor.position(), "distance_to_sqr")
       .mockReset()
       .mockImplementation(() => 4);
 
+    // Punch first time.
     objectPunchActor(object);
 
     expect(level.add_cam_effector).toHaveBeenCalledWith(animations.camera_effects_fusker, 999, false, "");
     expect(ActorInputManager.getInstance().setInactiveInputTime).toHaveBeenCalled();
-    expect(actor.drop_item).toHaveBeenCalled();
-    expect(actor.object(ak74.section())).toBeNull();
 
+    // Punch second time.
     objectPunchActor(object);
 
     expect(level.add_cam_effector).toHaveBeenCalledTimes(2);
     expect(ActorInputManager.getInstance().setInactiveInputTime).toHaveBeenCalledTimes(2);
-    expect(actor.drop_item).toHaveBeenCalledTimes(1);
-    expect(actor.object(ak74.section())).toBeNull();
-  });
-
-  it("'objectPunchActor' should not drop items when active slot is not primary or secondary", () => {
-    const actor: ClientObject = mockActorClientGameObject({
-      active_item: () => mockClientGameObject(),
-      inventory: [["wpn_ak74", mockClientGameObject({ sectionOverride: "wpn_ak74" })]],
-    });
-    const object: ClientObject = mockClientGameObject();
-
-    registerActor(actor);
-
-    jest.spyOn(actor.position(), "distance_to_sqr").mockImplementation(() => 4);
-    jest.spyOn(actor, "active_slot").mockImplementation(() => EActiveItemSlot.NONE);
-
-    objectPunchActor(object);
-
-    expect(actor.drop_item).not.toHaveBeenCalled();
-
-    jest.spyOn(actor, "active_slot").mockImplementation(() => EActiveItemSlot.KNIFE);
-
-    objectPunchActor(object);
-
-    expect(actor.drop_item).not.toHaveBeenCalled();
-
-    jest.spyOn(actor, "active_slot").mockImplementation(() => EActiveItemSlot.SECONDARY);
-
-    objectPunchActor(object);
-
-    expect(actor.drop_item).toHaveBeenCalled();
-
-    jest.spyOn(actor, "active_slot").mockImplementation(() => EActiveItemSlot.PRIMARY);
-
-    objectPunchActor(object);
-
-    expect(actor.drop_item).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/engine/core/utils/object/object_action.ts
+++ b/src/engine/core/utils/object/object_action.ts
@@ -3,7 +3,7 @@ import { level } from "xray16";
 import { registry } from "@/engine/core/database/registry";
 import { ActorInputManager } from "@/engine/core/managers/actor/ActorInputManager";
 import { animations } from "@/engine/lib/constants/animation";
-import { ClientObject, EActiveItemSlot, Optional } from "@/engine/lib/types";
+import { ClientObject } from "@/engine/lib/types";
 
 /**
  * Punch actor as object.
@@ -20,14 +20,4 @@ export function objectPunchActor(object: ClientObject): void {
 
   ActorInputManager.getInstance().setInactiveInputTime(30);
   level.add_cam_effector(animations.camera_effects_fusker, 999, false, "");
-
-  const activeSlot: EActiveItemSlot = actor.active_slot();
-
-  if (activeSlot === EActiveItemSlot.PRIMARY || activeSlot === EActiveItemSlot.SECONDARY) {
-    const activeItem: Optional<ClientObject> = actor.active_item();
-
-    if (activeItem) {
-      actor.drop_item(activeItem);
-    }
-  }
 }

--- a/src/engine/core/utils/object/object_danger.test.ts
+++ b/src/engine/core/utils/object/object_danger.test.ts
@@ -136,32 +136,32 @@ describe("'object_danger' utils", () => {
 
     state[EScheme.COMBAT_IGNORE] = combatIgnoreState;
     expect(canObjectSelectAsEnemy(object, enemy)).toBe(true);
-    expect(state.enemy_id).toBe(enemy.id());
+    expect(state.enemyId).toBe(enemy.id());
 
-    state.enemy_id = null;
+    state.enemyId = null;
     jest.spyOn(object, "alive").mockImplementationOnce(() => false);
     expect(canObjectSelectAsEnemy(object, enemy)).toBe(false);
-    expect(state.enemy_id).toBeNull();
+    expect(state.enemyId).toBeNull();
 
     expect(canObjectSelectAsEnemy(mockClientGameObject(), enemy)).toBe(true);
 
-    state.enemy_id = null;
+    state.enemyId = null;
     combatIgnoreState.overrides = {
       combat_ignore: {
         condlist: parseConditionsList(TRUE),
       },
     };
     expect(canObjectSelectAsEnemy(object, enemy)).toBe(false);
-    expect(state.enemy_id).toBe(enemy.id());
+    expect(state.enemyId).toBe(enemy.id());
 
-    state.enemy_id = null;
+    state.enemyId = null;
     combatIgnoreState.overrides = {
       combat_ignore: {
         condlist: parseConditionsList(FALSE),
       },
     };
     expect(canObjectSelectAsEnemy(object, enemy)).toBe(true);
-    expect(state.enemy_id).toBe(enemy.id());
+    expect(state.enemyId).toBe(enemy.id());
   });
 
   it("'canObjectSelectAsEnemy' should correctly check enemies in no-combat zones", () => {
@@ -186,7 +186,7 @@ describe("'object_danger' utils", () => {
     } as SmartTerrainControl;
 
     expect(canObjectSelectAsEnemy(object, enemy)).toBe(false);
-    expect(state.enemy_id).toBe(enemy.id());
+    expect(state.enemyId).toBe(enemy.id());
   });
 
   it("'canObjectSelectAsEnemy' should correctly ignore enemies in no-combat smarts", () => {
@@ -203,6 +203,6 @@ describe("'object_danger' utils", () => {
 
     state[EScheme.COMBAT_IGNORE] = combatIgnoreState;
     expect(canObjectSelectAsEnemy(object, enemy)).toBe(false);
-    expect(state.enemy_id).toBe(enemy.id());
+    expect(state.enemyId).toBe(enemy.id());
   });
 });

--- a/src/engine/core/utils/object/object_danger.ts
+++ b/src/engine/core/utils/object/object_danger.ts
@@ -87,7 +87,7 @@ export function isObjectFacingDanger(object: ClientObject): boolean {
   const ignoreDistanceByType: Optional<TDistance> = logicsConfig.DANGER_IGNORE_DISTANCE_BY_TYPE[bestDangerType];
   const ignoreDistance: TDistance =
     ignoreDistanceByType === null
-      ? logicsConfig.DANGER_IGNORE_DISTANCE_GENERAL * logicsConfig.DANGER_IGNORE_DISTANCE_GENERAL
+      ? logicsConfig.DANGER_IGNORE_DISTANCE_GENERAL_SQR
       : ignoreDistanceByType * ignoreDistanceByType;
 
   // Verify danger distance.
@@ -135,7 +135,8 @@ export function canObjectSelectAsEnemy(object: ClientObject, enemy: ClientObject
   ] as Optional<ISchemeCombatIgnoreState>;
 
   // todo: Probably also clean it up? And set only when 'true'
-  objectState.enemy_id = enemy.id();
+  objectState.enemyId = enemy.id();
+  objectState.enemy = enemy;
 
   // Combat ignoring is explicitly disabled.
   if (combatIgnoreState?.enabled === false) {
@@ -154,7 +155,7 @@ export function canObjectSelectAsEnemy(object: ClientObject, enemy: ClientObject
     return true;
   }
 
-  if (enemy.id() !== ACTOR_ID) {
+  if (objectState.enemyId !== ACTOR_ID) {
     // If enemy of object is in no-combat zone.
     for (const [name, storyId] of registry.noCombatZones) {
       const zone: Optional<ClientObject> = registry.zones.get(name);

--- a/src/engine/core/utils/object/object_setup.test.ts
+++ b/src/engine/core/utils/object/object_setup.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { registerActor } from "@/engine/core/database";
+import { setupObjectInfoPortions, setupObjectStalkerVisual } from "@/engine/core/utils/object/object_setup";
+import { ClientObject } from "@/engine/lib/types";
+import { expectCallsToEqual } from "@/fixtures/jest";
+import { mockActorClientGameObject, mockClientGameObject, mockIniFile } from "@/fixtures/xray";
+
+describe("object_setup utils", () => {
+  it("setupObjectVisual should setup visuals", () => {
+    const stalkerNone: ClientObject = mockClientGameObject({ section: <T>() => "stalker_none_1" as T });
+    const stalkerFreedom: ClientObject = mockClientGameObject({ section: <T>() => "stalker_freedom_1" as T });
+    const stalkerActor: ClientObject = mockClientGameObject({ section: <T>() => "stalker_actor_1" as T });
+
+    registerActor(mockActorClientGameObject());
+
+    setupObjectStalkerVisual(stalkerNone);
+    expect(stalkerNone.set_visual_name).not.toHaveBeenCalled();
+
+    setupObjectStalkerVisual(stalkerFreedom);
+    expect(stalkerFreedom.set_visual_name).toHaveBeenCalledWith("actors\\stalker_neutral\\stalker_neutral_2");
+
+    setupObjectStalkerVisual(stalkerActor);
+    expect(stalkerActor.set_visual_name).toHaveBeenCalledWith("some_actor_visual");
+  });
+
+  it("setupObjectInfoPortions should setup info portions", () => {
+    const first: ClientObject = mockClientGameObject();
+    const second: ClientObject = mockClientGameObject();
+
+    setupObjectInfoPortions(first, mockIniFile("test.ltx", {}));
+
+    expect(first.give_info_portion).not.toHaveBeenCalled();
+
+    setupObjectInfoPortions(
+      first,
+      mockIniFile("test.ltx", {
+        known_info: ["a", "b", "c"],
+      })
+    );
+    expect(first.give_info_portion).toHaveBeenCalledTimes(3);
+    expectCallsToEqual(first.give_info_portion, [["a"], ["b"], ["c"]]);
+
+    setupObjectInfoPortions(
+      second,
+      mockIniFile("test.ltx", {
+        custom_section: ["d", "e"],
+      }),
+      "custom_section"
+    );
+    expect(second.give_info_portion).toHaveBeenCalledTimes(2);
+    expectCallsToEqual(second.give_info_portion, [["d"], ["e"]]);
+  });
+});

--- a/src/engine/core/utils/object/object_setup.ts
+++ b/src/engine/core/utils/object/object_setup.ts
@@ -1,0 +1,51 @@
+import { ini_file } from "xray16";
+
+import { DUMMY_LTX, registry, SYSTEM_INI } from "@/engine/core/database";
+import { readIniString } from "@/engine/core/utils/ini";
+import { ClientObject, IniFile, Optional, TCount, TName, TSection } from "@/engine/lib/types";
+
+/**
+ * Setup object visuals based on global section description.
+ *
+ * @param object - target game object to initialize visuals for
+ */
+export function getObjectStalkerIni(object: ClientObject): IniFile {
+  const spawnIni: Optional<IniFile> = object.spawn_ini();
+  const stalkerIniFilename: Optional<TName> = spawnIni === null ? null : readIniString(spawnIni, "logic", "cfg", false);
+
+  return stalkerIniFilename ? new ini_file(stalkerIniFilename) : spawnIni ?? DUMMY_LTX;
+}
+
+/**
+ * Setup object visuals based on global section description.
+ *
+ * @param object - target game object to initialize visuals for
+ */
+export function setupObjectStalkerVisual(object: ClientObject): void {
+  const visual: TName = readIniString(SYSTEM_INI, object.section(), "set_visual", false);
+
+  if (visual !== null && visual !== "") {
+    object.set_visual_name(visual === "actor_visual" ? registry.actor.get_visual_name() : visual);
+  }
+}
+
+/**
+ * Setup object info portions for game object.
+ *
+ * @param object - target game to object to initialize info portions for
+ * @param ini - ini file to read info from
+ * @param section - ini file section to read info from
+ */
+export function setupObjectInfoPortions(object: ClientObject, ini: IniFile, section: Optional<TSection> = null): void {
+  section = section === null ? "known_info" : section;
+
+  if (ini.section_exist(section)) {
+    const knownInfosCount: TCount = ini.line_count(section);
+
+    for (const it of $range(0, knownInfosCount - 1)) {
+      const [, infoPortion] = ini.r_line(section, it, "", "");
+
+      object.give_info_portion(infoPortion);
+    }
+  }
+}

--- a/src/engine/lib/configs/LogicsConfig.ts
+++ b/src/engine/lib/configs/LogicsConfig.ts
@@ -13,6 +13,7 @@ export const logicsConfig = {
   ARTEFACT_OFFLINE_DISTANCE: 150,
   DANGER_INERTION_TIME: 15_000,
   DANGER_IGNORE_DISTANCE_GENERAL: 150,
+  DANGER_IGNORE_DISTANCE_GENERAL_SQR: 150 * 150,
   DANGER_IGNORE_DISTANCE_BY_TYPE: {
     [danger_object.grenade]: 15,
     [danger_object.entity_corpse]: 10,

--- a/src/engine/scripts/declarations/conditions/object.ts
+++ b/src/engine/scripts/declarations/conditions/object.ts
@@ -174,7 +174,7 @@ extern(
 extern(
   "xr_conditions.check_enemy_name",
   (actor: ClientObject, object: ClientObject, params: LuaArray<TName>): boolean => {
-    const enemyId: TNumberId = registry.objects.get(object.id()).enemy_id!;
+    const enemyId: TNumberId = registry.objects.get(object.id()).enemyId!;
     const enemy: Optional<ClientObject> = registry.objects.get(enemyId)?.object;
 
     if (enemy && enemy.alive()) {
@@ -355,7 +355,7 @@ extern("xr_conditions.heli_see_npc", (actor: ClientObject, object: ClientObject,
  * todo;
  */
 extern("xr_conditions.enemy_group", (actor: ClientObject, object: ClientObject, params: LuaTable<number>): boolean => {
-  const enemyId: TNumberId = registry.objects.get(object.id()).enemy_id as number;
+  const enemyId: TNumberId = registry.objects.get(object.id()).enemyId as number;
   const enemy: ClientObject = registry.objects.get(enemyId)?.object as ClientObject;
   const enemyGroup: TNumberId = enemy?.group();
 
@@ -1024,7 +1024,7 @@ extern("xr_conditions.dead_body_searching", (actor: ClientObject, object: Client
  * todo;
  */
 extern("xr_conditions.check_enemy_smart", (actor: ClientObject, object: ClientObject, params: [string]): boolean => {
-  const enemyId: Optional<TNumberId> = registry.objects.get(object.id()).enemy_id;
+  const enemyId: Optional<TNumberId> = registry.objects.get(object.id()).enemyId;
   const enemy: Optional<ClientObject> = enemyId ? registry.objects.get(enemyId)?.object : null;
 
   if (enemy === null || enemyId === alife().actor().id) {

--- a/src/engine/scripts/declarations/conditions/relation.ts
+++ b/src/engine/scripts/declarations/conditions/relation.ts
@@ -154,7 +154,7 @@ extern("xr_conditions.is_squad_neutral_to_actor", (actor: ClientObject, object: 
  * todo;
  */
 extern("xr_conditions.fighting_actor", (actor: ClientObject, object: ClientObject): boolean => {
-  const enemyId: TNumberId = registry.objects.get(object.id()).enemy_id!;
+  const enemyId: TNumberId = registry.objects.get(object.id()).enemyId!;
   const enemy: Optional<ClientObject> = registry.objects.get(enemyId)?.object as Optional<ClientObject>;
 
   return enemy !== null && enemy.id() === actor.id();

--- a/src/engine/scripts/declarations/dialogs/dialogs.ts
+++ b/src/engine/scripts/declarations/dialogs/dialogs.ts
@@ -7,7 +7,7 @@ import { SimulationBoardManager } from "@/engine/core/managers/simulation/Simula
 import { SurgeManager } from "@/engine/core/managers/surge/SurgeManager";
 import { updateStalkerLogic } from "@/engine/core/objects/binders/creature/StalkerBinder";
 import { ISchemeMeetState } from "@/engine/core/schemes/stalker/meet";
-import { updateObjectInteractionAvailability } from "@/engine/core/schemes/stalker/meet/utils";
+import { updateObjectMeetAvailability } from "@/engine/core/schemes/stalker/meet/utils";
 import { ISchemeWoundedState } from "@/engine/core/schemes/stalker/wounded";
 import { extern } from "@/engine/core/utils/binding";
 import { createGameAutoSave } from "@/engine/core/utils/game";
@@ -53,7 +53,7 @@ extern("dialogs.update_npc_dialog", (firstSpeaker: ClientObject, secondSpeaker: 
   const object: ClientObject = getNpcSpeaker(firstSpeaker, secondSpeaker);
 
   (registry.objects.get(object.id())[EScheme.MEET] as ISchemeMeetState).meetManager.update();
-  updateObjectInteractionAvailability(object);
+  updateObjectMeetAvailability(object);
   updateStalkerLogic(object);
 });
 

--- a/src/engine/scripts/start.test.ts
+++ b/src/engine/scripts/start.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 
+jest.mock("@/engine/core/utils/class_ids", () => ({ updateClassIds: jest.fn(), createClassIds: jest.fn() }));
+jest.mock("@/engine/core/utils/ini/ini_system", () => ({ unlockSystemIniOverriding: jest.fn() }));
+jest.mock("@/engine/scripts/register/extensions_registrator", () => ({ registerExtensions: jest.fn() }));
+jest.mock("@/engine/scripts/register/managers_registrator", () => ({ registerManagers: jest.fn() }));
+jest.mock("@/engine/scripts/register/schemes_registrator", () => ({ registerSchemes: jest.fn() }));
+
+import { updateClassIds } from "@/engine/core/utils/class_ids";
+import { unlockSystemIniOverriding } from "@/engine/core/utils/ini";
 import { AnyObject } from "@/engine/lib/types";
+import { registerExtensions } from "@/engine/scripts/register/extensions_registrator";
+import { registerManagers } from "@/engine/scripts/register/managers_registrator";
+import { registerSchemes } from "@/engine/scripts/register/schemes_registrator";
 
 describe("'start' entry point", () => {
   const checkBinding = (name: string, container: AnyObject = global) => {
@@ -13,5 +24,17 @@ describe("'start' entry point", () => {
     require("@/engine/scripts/start");
 
     checkBinding("callback");
+  });
+
+  it("should correctly init methods on start", () => {
+    require("@/engine/scripts/start");
+
+    (global as AnyObject).start.callback();
+
+    expect(updateClassIds).toHaveBeenCalledTimes(1);
+    expect(unlockSystemIniOverriding).toHaveBeenCalledTimes(1);
+    expect(registerExtensions).toHaveBeenCalledTimes(1);
+    expect(registerManagers).toHaveBeenCalledTimes(1);
+    expect(registerSchemes).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/engine/scripts/start.ts
+++ b/src/engine/scripts/start.ts
@@ -1,5 +1,4 @@
-import { time_global } from "xray16";
-
+import { registerSimulator } from "@/engine/core/database/simulation";
 import { EGameEvent, EventsManager } from "@/engine/core/managers/events";
 import { extern } from "@/engine/core/utils/binding";
 import { updateClassIds } from "@/engine/core/utils/class_ids";
@@ -23,9 +22,8 @@ extern("start", {
   callback: (): void => {
     logger.info("Start new game");
 
-    math.randomseed(time_global());
-
     updateClassIds(classIds);
+    registerSimulator();
 
     unlockSystemIniOverriding();
 

--- a/src/fixtures/xray/mocks/ini/files.mock.ts
+++ b/src/fixtures/xray/mocks/ini/files.mock.ts
@@ -64,6 +64,15 @@ export const FILES_MOCKS: Record<TPath, AnyObject> = {
     "test-squad": {
       faction: "stalker",
     },
+    stalker_none_1: {
+      set_visual: "",
+    },
+    stalker_freedom_1: {
+      set_visual: "actors\\stalker_neutral\\stalker_neutral_2",
+    },
+    stalker_actor_1: {
+      set_visual: "actor_visual",
+    },
   },
   "spawn.ini": {
     story_object: {

--- a/src/fixtures/xray/mocks/objects/client/game_object.mock.ts
+++ b/src/fixtures/xray/mocks/objects/client/game_object.mock.ts
@@ -130,6 +130,7 @@ export function mockClientGameObject({
     clear_animations: rest.clear_animations || jest.fn(),
     command: rest.command || jest.fn(),
     critically_wounded: rest.critically_wounded || jest.fn(() => false),
+    debug_planner: rest.debug_planner || jest.fn(),
     direction: rest.direction || jest.fn(() => objectDirection),
     disable_hit_marks: rest.disable_hit_marks || jest.fn(),
     disable_info_portion:

--- a/src/fixtures/xray/mocks/objects/client/game_object.mock.ts
+++ b/src/fixtures/xray/mocks/objects/client/game_object.mock.ts
@@ -159,6 +159,7 @@ export function mockClientGameObject({
       jest.fn((to: ClientObject) => {
         return mockRelationRegistryInterface.get_general_goodwill_between(id ? id() : idOverride, to.id());
       }),
+    get_visual_name: rest.get_visual_name || jest.fn(() => "some_stalker_visual"),
     get_campfire: rest.get_campfire || jest.fn(() => null),
     get_current_point_index: rest.get_current_point_index || jest.fn(() => null),
     get_script: rest.get_script || jest.fn(() => false),
@@ -288,6 +289,7 @@ export function mockClientGameObject({
     set_relation: rest.set_relation || jest.fn(),
     set_sound_mask: rest.set_sound_mask || jest.fn(),
     set_sympathy: rest.set_sympathy || jest.fn(),
+    set_visual_name: rest.set_visual_name || jest.fn(),
     sight_params:
       rest.sight_params ||
       jest.fn(() => {
@@ -364,5 +366,9 @@ export function mockActorClientGameObject(
     }
   > = {}
 ): ClientObject {
-  return mockClientGameObject({ ...base, idOverride: ACTOR_ID });
+  return mockClientGameObject({
+    ...base,
+    idOverride: ACTOR_ID,
+    get_visual_name: base.get_visual_name || jest.fn(() => "some_actor_visual" as any),
+  });
 }

--- a/src/fixtures/xray/mocks/objects/client/object_binder.mock.ts
+++ b/src/fixtures/xray/mocks/objects/client/object_binder.mock.ts
@@ -1,15 +1,14 @@
 import { ClientObject } from "@/engine/lib/types";
 import { MockLuabindClass } from "@/fixtures/xray/mocks/luabind.mock";
+import { MockNetProcessor } from "@/fixtures/xray/mocks/save";
 
 /**
- * todo;
+ * Mocking binder object that wraps client objects lifecycle.
  */
 export class MockObjectBinder extends MockLuabindClass {
   public constructor(public object: ClientObject) {
     super();
   }
-
-  public load(): void {}
 
   public net_Relcase(): void {}
 
@@ -31,7 +30,13 @@ export class MockObjectBinder extends MockLuabindClass {
 
   public reload(): void {}
 
-  public save(): void {}
+  public save(packet: MockNetProcessor): void {
+    packet.w_stringZ("save_from_" + this.constructor.name);
+  }
+
+  public load(packet: MockNetProcessor): void {
+    packet.r_stringZ();
+  }
 
   public update(): void {}
 }

--- a/src/fixtures/xray/mocks/save/NetProcessor.mock.ts
+++ b/src/fixtures/xray/mocks/save/NetProcessor.mock.ts
@@ -1,4 +1,4 @@
-import { NetPacket, NetProcessor } from "@/engine/lib/types";
+import { NetPacket, NetProcessor, Reader } from "@/engine/lib/types";
 import { EPacketDataType } from "@/fixtures/xray/mocks/save/types";
 
 /**
@@ -151,4 +151,11 @@ export function mockNetProcessor(packet: MockNetProcessor = new MockNetProcessor
  */
 export function mockNetPacket(packet: MockNetProcessor = new MockNetProcessor()): NetPacket {
   return packet as unknown as NetPacket;
+}
+
+/**
+ * Mock reader instance.
+ */
+export function mockNetReader(packet: MockNetProcessor = new MockNetProcessor()): Reader {
+  return packet as unknown as Reader;
 }


### PR DESCRIPTION
## Changes

- Store alife simulator in DB
- Test super.load/save calls with jest
- Remove useless condlists for base job ltx configs
- Remove `bye` from default meet configs / job configs. Stalkers should not say `hello` when leaving them
- Tests for stalker binder saving/loading
- Simplified stalker binder -> moved shared methods to utils
- Do not set math random seed -> it is set in xray engine already and based on OS time, in lua it was always setting from `time_global` 0 values
- Mocks updates

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are included
- [x] documentation is changed or added
