### PR TITLE
[GENERIC] Simplify `readIniString` usage.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,9 +9,6 @@ test:
   - src/**/*.test.ts
   - src/fixtures/**
 
-engine:
-  - src/engine/**
-
 configs:
   - src/engine/forms/**
 

--- a/src/engine/core/database/logic.test.ts
+++ b/src/engine/core/database/logic.test.ts
@@ -34,7 +34,7 @@ describe("'logic' database module", () => {
     state.iniFilename = "test2.ltx";
     state.sectionLogic = "section_ex";
     state.activeSection = "active_sect_ex";
-    state.smartTerrainName = "gulag_name_ex";
+    state.smartTerrainName = "smart_terrain_name_ex";
     state.activeScheme = EScheme.COMBAT;
     state.activationTime = 15_000;
     state.activationGameTime = time;
@@ -51,7 +51,7 @@ describe("'logic' database module", () => {
       "test2.ltx",
       "section_ex",
       "active_sect_ex",
-      "gulag_name_ex",
+      "smart_terrain_name_ex",
       10000,
       15,
       5,
@@ -126,7 +126,7 @@ describe("'logic' database module", () => {
     expect(nextState.loadedIniFilename).toBe("test2.ltx");
     expect(nextState.loadedSectionLogic).toBe("section_ex");
     expect(nextState.loadedActiveSection).toBe("active_sect_ex");
-    expect(nextState.loadedSmartTerrainName).toBe("gulag_name_ex");
+    expect(nextState.loadedSmartTerrainName).toBe("smart_terrain_name_ex");
     expect(nextState.activationTime).toBe(15_000);
     expect(nextState.activationGameTime.toString()).toBe(time.toString());
 

--- a/src/engine/core/database/logic.ts
+++ b/src/engine/core/database/logic.ts
@@ -63,13 +63,13 @@ export function loadObjectLogic(object: ClientObject, reader: NetProcessor): voi
   const iniFilename: Optional<TName> = reader.r_stringZ();
   const sectionLogic: Optional<TSection> = reader.r_stringZ();
   const activeSection: StringOptional = reader.r_stringZ();
-  const gulagName: TName = reader.r_stringZ();
+  const smartTerrainName: TName = reader.r_stringZ();
 
   state.jobIni = jobIni === "" ? null : jobIni;
   state.loadedIniFilename = iniFilename === "" ? null : iniFilename;
   state.loadedSectionLogic = sectionLogic === "" ? null : sectionLogic;
   state.loadedActiveSection = activeSection === "" ? NIL : activeSection;
-  state.loadedSmartTerrainName = gulagName;
+  state.loadedSmartTerrainName = smartTerrainName;
 
   state.activationTime = reader.r_s32() + time_global();
   state.activationGameTime = readTimeFromPacket(reader) as Time;

--- a/src/engine/core/database/monster.ts
+++ b/src/engine/core/database/monster.ts
@@ -16,7 +16,7 @@ const logger: LuaLogger = new LuaLogger($filename);
  * @returns monster state from ini config or null
  */
 export function getMonsterState(ini: IniFile, section: TSection): Optional<EMonsterState> {
-  const state: EMonsterState = readIniString(ini, section, "state", false, "", "") as EMonsterState;
+  const state: EMonsterState = readIniString(ini, section, "state", false, null, "") as EMonsterState;
 
   return state === EMonsterState.NONE ? null : state;
 }

--- a/src/engine/core/database/story_objects.ts
+++ b/src/engine/core/database/story_objects.ts
@@ -35,7 +35,7 @@ export function registerObjectStoryLinks(serverObject: ServerObject): void {
   }
 
   const spawnSection: TName = serverObject.section_name();
-  const storyId: Optional<TStringId> = readIniString(SYSTEM_INI, spawnSection, "story_id", false, "", null);
+  const storyId: Optional<TStringId> = readIniString(SYSTEM_INI, spawnSection, "story_id", false);
 
   if (storyId !== null) {
     registerStoryLink(serverObject.id, storyId);

--- a/src/engine/core/managers/actor/ActorInventoryMenuManager.ts
+++ b/src/engine/core/managers/actor/ActorInventoryMenuManager.ts
@@ -19,10 +19,10 @@ export class ActorInventoryMenuManager extends AbstractManager {
   public override initialize(): void {
     const ini: IniFile = SYSTEM_INI;
 
-    executeConsoleCommand(consoleCommands.slot_0, readIniString(ini, ACTOR, "quick_item_1", false, "", ""));
-    executeConsoleCommand(consoleCommands.slot_1, readIniString(ini, ACTOR, "quick_item_2", false, "", ""));
-    executeConsoleCommand(consoleCommands.slot_2, readIniString(ini, ACTOR, "quick_item_3", false, "", ""));
-    executeConsoleCommand(consoleCommands.slot_3, readIniString(ini, ACTOR, "quick_item_4", false, "", ""));
+    executeConsoleCommand(consoleCommands.slot_0, readIniString(ini, ACTOR, "quick_item_1", false, null, ""));
+    executeConsoleCommand(consoleCommands.slot_1, readIniString(ini, ACTOR, "quick_item_2", false, null, ""));
+    executeConsoleCommand(consoleCommands.slot_2, readIniString(ini, ACTOR, "quick_item_3", false, null, ""));
+    executeConsoleCommand(consoleCommands.slot_3, readIniString(ini, ACTOR, "quick_item_4", false, null, ""));
   }
 
   /**

--- a/src/engine/core/managers/death/ReleaseBodyManager.ts
+++ b/src/engine/core/managers/death/ReleaseBodyManager.ts
@@ -155,7 +155,7 @@ export class ReleaseBodyManager extends AbstractManager {
     let characterIni: Optional<IniFile> = null;
     const objectSpawnIni: Optional<IniFile> = object.spawn_ini();
     const filename: Optional<TName> =
-      objectSpawnIni === null ? null : readIniString(objectSpawnIni, "logic", "cfg", false, "");
+      objectSpawnIni === null ? null : readIniString(objectSpawnIni, "logic", "cfg", false);
 
     if (filename !== null) {
       if (!getFS().exist(roots.gameConfig, filename)) {
@@ -168,8 +168,7 @@ export class ReleaseBodyManager extends AbstractManager {
     }
 
     const state: IRegistryObjectState = registry.objects.get(object.id());
-    const knownInfo: TSection =
-      readIniString(characterIni, state.sectionLogic, "known_info", false, "", null) || "known_info";
+    const knownInfo: TSection = readIniString(characterIni, state.sectionLogic, "known_info", false) || "known_info";
 
     return characterIni.section_exist(knownInfo);
   }

--- a/src/engine/core/managers/map/MapDisplayManager.ts
+++ b/src/engine/core/managers/map/MapDisplayManager.ts
@@ -94,9 +94,9 @@ export class MapDisplayManager extends AbstractManager {
     let spotSection;
 
     if (scheme === null || scheme === NIL) {
-      spotSection = readIniString(state.ini, state.sectionLogic, "show_spot", false, "");
+      spotSection = readIniString(state.ini, state.sectionLogic, "show_spot", false);
     } else {
-      spotSection = readIniString(state.ini, section, "show_spot", false, "");
+      spotSection = readIniString(state.ini, section, "show_spot", false);
     }
 
     if (spotSection === null) {
@@ -108,12 +108,11 @@ export class MapDisplayManager extends AbstractManager {
       state.ini,
       state.sectionLogic,
       "level_spot",
-      false,
-      ""
+      false
     ) as EMapMarkType;
 
     if (mapSpot === null) {
-      mapSpot = readIniString(state.ini!, section, "level_spot", false, "") as EMapMarkType;
+      mapSpot = readIniString(state.ini!, section, "level_spot", false) as EMapMarkType;
     }
 
     if (mapSpot !== null) {
@@ -169,13 +168,12 @@ export class MapDisplayManager extends AbstractManager {
       state.ini,
       state.sectionLogic,
       "level_spot",
-      false,
-      ""
+      false
     ) as EMapMarkType;
 
     // todo: Retry, probably not needed at all.
     if (mapSpot === null) {
-      mapSpot = readIniString<EMapMarkType>(state.ini, state.activeSection, "level_spot", false, "") as EMapMarkType;
+      mapSpot = readIniString<EMapMarkType>(state.ini, state.activeSection, "level_spot", false) as EMapMarkType;
     }
 
     if (mapSpot !== null) {

--- a/src/engine/core/managers/sounds/GlobalSoundManager.ts
+++ b/src/engine/core/managers/sounds/GlobalSoundManager.ts
@@ -75,8 +75,7 @@ export class GlobalSoundManager extends AbstractManager {
         SCRIPT_SOUND_LTX,
         section,
         "type",
-        true,
-        ""
+        true
       ) as EPlayableSound;
 
       switch (type) {

--- a/src/engine/core/managers/tasks/TaskObject.ts
+++ b/src/engine/core/managers/tasks/TaskObject.ts
@@ -132,16 +132,16 @@ export class TaskObject {
     this.id = id;
     this.ini = ini;
 
-    this.title = readIniString(ini, id, "title", false, "", "TITLE_DOESNT_EXIST");
-    this.titleGetterFunctorName = readIniString(ini, id, "title_functor", false, "", "condlist");
+    this.title = readIniString(ini, id, "title", false, null, "TITLE_DOESNT_EXIST");
+    this.titleGetterFunctorName = readIniString(ini, id, "title_functor", false, null, "condlist");
 
-    this.description = readIniString(ini, id, "descr", false, "", "DESCR_DOESNT_EXIST");
-    this.descriptionGetterFunctorName = readIniString(ini, id, "descr_functor", false, "", "condlist");
+    this.description = readIniString(ini, id, "descr", false, null, "DESCR_DOESNT_EXIST");
+    this.descriptionGetterFunctorName = readIniString(ini, id, "descr_functor", false, null, "condlist");
 
-    this.target = readIniString(ini, id, "target", false, "", "DESCR_DOESNT_EXIST");
-    this.targetGetterFunctorName = readIniString(ini, id, "target_functor", false, "", "target_condlist");
+    this.target = readIniString(ini, id, "target", false, null, "DESCR_DOESNT_EXIST");
+    this.targetGetterFunctorName = readIniString(ini, id, "target_functor", false, null, "target_condlist");
 
-    this.icon = readIniString(ini, id, "icon", false, "", "ui_pda2_mtask_overlay");
+    this.icon = readIniString(ini, id, "icon", false, null, "ui_pda2_mtask_overlay");
     this.priority = readIniNumber(ini, id, "prior", false, 0);
     this.isStorylineTask = readIniBoolean(ini, id, "storyline", false, true);
 
@@ -155,12 +155,12 @@ export class TaskObject {
       it = it + 1;
     }
 
-    this.onInit = parseConditionsList(readIniString(ini, id, "on_init", false, "", ""));
-    this.onComplete = parseConditionsList(readIniString(ini, id, "on_complete", false, "", ""));
-    this.onReversed = parseConditionsList(readIniString(ini, id, "on_reversed", false, "", ""));
+    this.onInit = parseConditionsList(readIniString(ini, id, "on_init", false, null, ""));
+    this.onComplete = parseConditionsList(readIniString(ini, id, "on_complete", false, null, ""));
+    this.onReversed = parseConditionsList(readIniString(ini, id, "on_reversed", false, null, ""));
 
-    this.rewardMoneyConditionList = parseConditionsList(readIniString(ini, id, "reward_money", false, "", ""));
-    this.rewardItemsConditionList = parseConditionsList(readIniString(ini, id, "reward_item", false, "", ""));
+    this.rewardMoneyConditionList = parseConditionsList(readIniString(ini, id, "reward_money", false, null, ""));
+    this.rewardItemsConditionList = parseConditionsList(readIniString(ini, id, "reward_item", false, null, ""));
 
     this.communityRelationDeltaFail = readIniNumber(ini, id, "community_relation_delta_fail", false, 0);
     this.communityRelationDeltaComplete = readIniNumber(ini, id, "community_relation_delta_complete", false, 0);

--- a/src/engine/core/managers/trade/TradeManager.ts
+++ b/src/engine/core/managers/trade/TradeManager.ts
@@ -51,7 +51,7 @@ export class TradeManager extends AbstractManager {
       "trader",
       "buy_item_condition_factor",
       false,
-      "",
+      null,
       "0.7"
     );
 
@@ -156,7 +156,7 @@ export class TradeManager extends AbstractManager {
    */
   public getBuyDiscountForObject(objectId: TNumberId): TRate {
     const tradeDescriptor: ITradeManagerDescriptor = registry.trade.get(objectId);
-    const data: string = readIniString(tradeDescriptor.config, "trader", "discounts", false, "", "");
+    const data: string = readIniString(tradeDescriptor.config, "trader", "discounts", false, null, "");
 
     if (data === "") {
       return 1;

--- a/src/engine/core/managers/travel/TravelManager.ts
+++ b/src/engine/core/managers/travel/TravelManager.ts
@@ -15,7 +15,7 @@ import { Squad } from "@/engine/core/objects/server/squad/Squad";
 import { abort } from "@/engine/core/utils/assertion";
 import { createGameAutoSave } from "@/engine/core/utils/game/game_save";
 import { parseConditionsList, pickSectionFromCondList } from "@/engine/core/utils/ini";
-import { LuaLogger } from "@/engine/core/utils/logging";
+import { ELuaLoggerMode, LuaLogger } from "@/engine/core/utils/logging";
 import {
   getObjectCommunity,
   getObjectSmartTerrain,
@@ -48,7 +48,7 @@ import {
   Vector,
 } from "@/engine/lib/types";
 
-const logger: LuaLogger = new LuaLogger($filename);
+const logger: LuaLogger = new LuaLogger($filename, { file: "travel", mode: ELuaLoggerMode.DUAL });
 
 /**
  * Manager to handle fast traveling of actor.

--- a/src/engine/core/managers/weather/WeatherManager.ts
+++ b/src/engine/core/managers/weather/WeatherManager.ts
@@ -174,7 +174,7 @@ export class WeatherManager extends AbstractManager {
       level.name() + "_surge_settings",
       "surge_state",
       false,
-      "",
+      null,
       "0"
     );
 
@@ -381,7 +381,7 @@ export class WeatherManager extends AbstractManager {
     logger.info("Initialize weather on network spawn");
 
     const levelName: TName = level.name();
-    const levelWeather: TName = readIniString(GAME_LTX, levelName, "weathers", false, "", "[default]");
+    const levelWeather: TName = readIniString(GAME_LTX, levelName, "weathers", false, null, "[default]");
 
     this.weatherSection = levelWeather;
     this.weatherConditionList = parseConditionsList(levelWeather);

--- a/src/engine/core/objects/ai/restriction/ObjectRestrictionsManager.ts
+++ b/src/engine/core/objects/ai/restriction/ObjectRestrictionsManager.ts
@@ -63,7 +63,7 @@ export class ObjectRestrictionsManager {
     // logger.info("Activate restrictions:", objectName, section);
 
     // Update OUT restrictors based on active / ini restrictors.
-    const outRestrictorString: string = readIniString(ini, section, "out_restr", false, "", "");
+    const outRestrictorString: string = readIniString(ini, section, "out_restr", false, null, "");
     const newOutRestrictors: LuaArray<TName> = parseStringsList(outRestrictorString);
     const oldOutRestrictors: LuaArray<TName> = parseStringsList(this.object.out_restrictions());
 
@@ -114,7 +114,7 @@ export class ObjectRestrictionsManager {
     }
 
     // Update IN restrictors based on active / ini restrictors.
-    const inRestrictorString: string = readIniString(ini, section, "in_restr", false, "", "");
+    const inRestrictorString: string = readIniString(ini, section, "in_restr", false, null, "");
     const newInRestrictor: LuaArray<TName> = parseStringsList(inRestrictorString);
     const oldInRestrictor: LuaArray<TName> = parseStringsList(this.object.in_restrictions());
 

--- a/src/engine/core/objects/binders/HelicopterBinder.ts
+++ b/src/engine/core/objects/binders/HelicopterBinder.ts
@@ -85,9 +85,9 @@ export class HelicopterBinder extends object_binder {
 
     const objectIni: IniFile = this.object.spawn_ini();
 
-    this.sndHit = readIniString(objectIni, "helicopter", "snd_hit", false, "", "heli_hit");
-    this.sndDamage = readIniString(objectIni, "helicopter", "snd_damage", false, "", "heli_damaged");
-    this.sndDown = readIniString(objectIni, "helicopter", "snd_down", false, "", "heli_down");
+    this.sndHit = readIniString(objectIni, "helicopter", "snd_hit", false, null, "heli_hit");
+    this.sndDamage = readIniString(objectIni, "helicopter", "snd_damage", false, null, "heli_damaged");
+    this.sndDown = readIniString(objectIni, "helicopter", "snd_down", false, null, "heli_down");
   }
 
   public override update(delta: number): void {

--- a/src/engine/core/objects/binders/physic/LabX8DoorBinder.ts
+++ b/src/engine/core/objects/binders/physic/LabX8DoorBinder.ts
@@ -72,7 +72,7 @@ export class LabX8DoorBinder extends object_binder {
       return;
     }
 
-    const filename: Optional<TName> = readIniString(ini, ANIMATED_OBJECT_SECT, "cfg", false, "", null);
+    const filename: Optional<TName> = readIniString(ini, ANIMATED_OBJECT_SECT, "cfg", false);
 
     if (filename) {
       ini = new ini_file(filename);
@@ -85,7 +85,7 @@ export class LabX8DoorBinder extends object_binder {
       ANIMATED_OBJECT_SECT,
       "idle_snd",
       false,
-      "",
+      null,
       "device\\airtight_door_idle"
     );
     const startSound: TPath = readIniString(
@@ -93,7 +93,7 @@ export class LabX8DoorBinder extends object_binder {
       ANIMATED_OBJECT_SECT,
       "start_snd",
       false,
-      "",
+      null,
       "device\\airtight_door_start"
     );
     const stopSound: TPath = readIniString(
@@ -101,7 +101,7 @@ export class LabX8DoorBinder extends object_binder {
       ANIMATED_OBJECT_SECT,
       "stop_snd",
       false,
-      "",
+      null,
       "device\\airtight_door_stop"
     );
 
@@ -117,7 +117,7 @@ export class LabX8DoorBinder extends object_binder {
       this.stopSound = new sound_object(stopSound);
     }
 
-    this.tip = parseConditionsList(readIniString(ini, ANIMATED_OBJECT_SECT, "tip", false, "", "none"));
+    this.tip = parseConditionsList(readIniString(ini, ANIMATED_OBJECT_SECT, "tip", false, null, "none"));
 
     let onUse: string = TRUE;
     let onStart: string = TRUE;

--- a/src/engine/core/objects/binders/physic/PhysicObjectItemBox.ts
+++ b/src/engine/core/objects/binders/physic/PhysicObjectItemBox.ts
@@ -142,7 +142,7 @@ export class PhysicObjectItemBox {
     const currentBoxItems = PhysicObjectItemBox.readBoxItemList(ini, "drop_box", "items", this.object);
 
     if (currentBoxItems === null) {
-      const community = readIniString(ini, "drop_box", "community", false, "", "def_box");
+      const community = readIniString(ini, "drop_box", "community", false, null, "def_box");
       const boxItemsToSpawn: LuaTable<TInventoryItem, TProbability> =
         itemByCommunity.get(community) ?? itemByCommunity.get("def_box");
 

--- a/src/engine/core/objects/binders/zones/AnomalyZoneBinder.ts
+++ b/src/engine/core/objects/binders/zones/AnomalyZoneBinder.ts
@@ -114,7 +114,7 @@ export class AnomalyZoneBinder extends object_binder {
       return;
     }
 
-    const filename: Optional<string> = readIniString(this.ini, ANOMAL_ZONE_SECTION, "cfg", false, "", null);
+    const filename: Optional<string> = readIniString(this.ini, ANOMAL_ZONE_SECTION, "cfg", false);
 
     // logger.info("Init anomaly zone from file:", object.name(), filename);
 
@@ -132,17 +132,17 @@ export class AnomalyZoneBinder extends object_binder {
     const defaultMaxArtefacts: TCount = readIniNumber(ini, ANOMAL_ZONE_SECTION, "max_artefacts", false, 3);
     const defaultForceXZ: TRate = readIniNumber(ini, ANOMAL_ZONE_SECTION, "applying_force_xz", false, 200);
     const defaultForceY: TRate = readIniNumber(ini, ANOMAL_ZONE_SECTION, "applying_force_y", false, 400);
-    const defaultArtefacts: Optional<string> = readIniString(ini, ANOMAL_ZONE_SECTION, "artefacts", false, "", null);
-    const defaultSpawned: Optional<string> = readIniString(ini, ANOMAL_ZONE_SECTION, "start_artefact", false, "", null);
-    const defaultWays: Optional<string> = readIniString(ini, ANOMAL_ZONE_SECTION, "artefact_ways", false, "", null);
-    const defaultFieldName: Optional<string> = readIniString(ini, ANOMAL_ZONE_SECTION, "field_name", false, "", null);
-    const defaultCoeffs: Optional<string> = readIniString(ini, ANOMAL_ZONE_SECTION, "coeff", false, "", null);
+    const defaultArtefacts: Optional<string> = readIniString(ini, ANOMAL_ZONE_SECTION, "artefacts", false);
+    const defaultSpawned: Optional<string> = readIniString(ini, ANOMAL_ZONE_SECTION, "start_artefact", false);
+    const defaultWays: Optional<string> = readIniString(ini, ANOMAL_ZONE_SECTION, "artefact_ways", false);
+    const defaultFieldName: Optional<string> = readIniString(ini, ANOMAL_ZONE_SECTION, "field_name", false);
+    const defaultCoeffs: Optional<string> = readIniString(ini, ANOMAL_ZONE_SECTION, "coeff", false);
     const defaultCoeffSectionName: string = readIniString(
       ini,
       ANOMAL_ZONE_SECTION,
       "coeffs_section",
       false,
-      "",
+      null,
       "{+actor_was_in_many_bad_places} coeff2, coeff"
     );
 
@@ -185,7 +185,7 @@ export class AnomalyZoneBinder extends object_binder {
         section,
         "start_artefact",
         false,
-        "",
+        null,
         defaultSpawned
       );
 
@@ -194,17 +194,17 @@ export class AnomalyZoneBinder extends object_binder {
         this.artefactsStartList.set(section, parseStringsList(initialArtefacts));
       }
 
-      const coeffsSection: string = readIniString(ini, section, "coeffs_section", false, "", defaultCoeffSectionName);
+      const coeffsSection: string = readIniString(ini, section, "coeffs_section", false, null, defaultCoeffSectionName);
       const conditionsList: TConditionList = parseConditionsList(coeffsSection);
       const coeffsSectionName: string = pickSectionFromCondList(registry.actor, null, conditionsList)!;
-      const coeffs: Optional<string> = readIniString(ini, section, coeffsSectionName, false, "", defaultCoeffs);
+      const coeffs: Optional<string> = readIniString(ini, section, coeffsSectionName, false, null, defaultCoeffs);
       /**
        * end todo;
        */
 
       this.artefactsSpawnCoefficients.set(section, coeffs === null ? new LuaTable() : parseNumbersList(coeffs));
 
-      const path: Optional<string> = readIniString(ini, section, "artefact_ways", false, "", defaultWays);
+      const path: Optional<string> = readIniString(ini, section, "artefact_ways", false, null, defaultWays);
 
       if (path === null) {
         abort("There is no field 'artefact_ways' in section [%s] in obj [%s]", section, object.name());
@@ -213,7 +213,7 @@ export class AnomalyZoneBinder extends object_binder {
       this.artefactsPathsList.set(section, parseStringsList(path));
 
       if (this.isCustomPlacement) {
-        const field: Optional<string> = readIniString(ini, section, "field_name", false, "", defaultFieldName);
+        const field: Optional<string> = readIniString(ini, section, "field_name", false, null, defaultFieldName);
 
         if (field === null) {
           this.fieldsTable.set(section, new LuaTable());
@@ -222,7 +222,7 @@ export class AnomalyZoneBinder extends object_binder {
           this.fieldsTable.set(section, parseStringsList(field));
         }
 
-        const minesSection: Optional<TSection> = readIniString(ini, section, "mines_section", true, "", null);
+        const minesSection: Optional<TSection> = readIniString(ini, section, "mines_section", true);
 
         if (minesSection === null) {
           abort("There is no field 'mines_section' in section [%s] in obj [%s]", section, object.name());
@@ -730,7 +730,7 @@ export class AnomalyZoneBinder extends object_binder {
       section,
       "artefacts",
       false,
-      "",
+      null,
       defaultArtefacts
     );
 

--- a/src/engine/core/objects/binders/zones/CampZoneBinder.ts
+++ b/src/engine/core/objects/binders/zones/CampZoneBinder.ts
@@ -50,7 +50,7 @@ export class CampZoneBinder extends object_binder {
 
     // If camp logic description present, try to read it from spawn ini or from defined `cfg` file.
     if (ini.section_exist("camp")) {
-      const filename: Optional<TName> = readIniString(ini, "camp", "cfg", false, "", null);
+      const filename: Optional<TName> = readIniString(ini, "camp", "cfg", false);
       const manager: CampManager = new CampManager(this.object, filename === null ? ini : new ini_file(filename));
 
       registerCampZone(this.object, manager);

--- a/src/engine/core/objects/camp/CampManager.ts
+++ b/src/engine/core/objects/camp/CampManager.ts
@@ -75,9 +75,9 @@ export class CampManager {
     this.object = object;
     this.ini = ini;
 
-    const stories: string = readIniString(ini, "camp", "stories", false, "", "test_story");
-    const guitars: string = readIniString(ini, "camp", "guitar_themes", false, "", "test_guitar");
-    const harmonicas: string = readIniString(ini, "camp", "harmonica_themes", false, "", "test_harmonica");
+    const stories: string = readIniString(ini, "camp", "stories", false, null, "test_story");
+    const guitars: string = readIniString(ini, "camp", "guitar_themes", false, null, "test_guitar");
+    const harmonicas: string = readIniString(ini, "camp", "harmonica_themes", false, null, "test_harmonica");
 
     this.storyTable = parseStringsList(stories);
     this.guitarTable = parseStringsList(guitars);

--- a/src/engine/core/objects/server/creature/Monster.ts
+++ b/src/engine/core/objects/server/creature/Monster.ts
@@ -59,7 +59,7 @@ export class Monster extends cse_alife_monster_base {
     this.brain().can_choose_alife_tasks(false);
 
     const objectIni: IniFile = this.spawn_ini();
-    const smartName: TName = readIniString(objectIni, "logic", "smart_terrain", false, "", "");
+    const smartName: TName = readIniString(objectIni, "logic", "smart_terrain", false, null, "");
     const smartTerrain: Optional<SmartTerrain> = simulationBoardManager.getSmartTerrainByName(smartName);
 
     if (smartTerrain !== null) {

--- a/src/engine/core/objects/server/creature/Stalker.ts
+++ b/src/engine/core/objects/server/creature/Stalker.ts
@@ -59,7 +59,7 @@ export class Stalker extends cse_alife_human_stalker {
 
     this.brain().can_choose_alife_tasks(false);
 
-    const smartName: TName = readIniString(objectIni, "logic", "smart_terrain", false, "", "");
+    const smartName: TName = readIniString(objectIni, "logic", "smart_terrain", false, null, "");
     const smartTerrain: Optional<SmartTerrain> = simulationBoardManager.getSmartTerrainByName(smartName);
 
     if (smartTerrain) {

--- a/src/engine/core/objects/server/smart_terrain/SmartTerrain.ts
+++ b/src/engine/core/objects/server/smart_terrain/SmartTerrain.ts
@@ -551,7 +551,7 @@ export class SmartTerrain extends cse_alife_smart_zone implements ISimulationTar
 
     assert(this.ini.section_exist(SMART_TERRAIN_SECTION), "Smart terrain '%s' no configuration.", this.name());
 
-    const filename: Optional<TName> = readIniString(this.ini, SMART_TERRAIN_SECTION, "cfg", false, "");
+    const filename: Optional<TName> = readIniString(this.ini, SMART_TERRAIN_SECTION, "cfg", false);
 
     if (filename !== null) {
       if (getFS().exist(roots.gameConfig, filename)) {
@@ -566,7 +566,7 @@ export class SmartTerrain extends cse_alife_smart_zone implements ISimulationTar
       SMART_TERRAIN_SECTION,
       "sim_type",
       false,
-      "",
+      null,
       ESimulationTerrainRole.DEFAULT
     ) as ESimulationTerrainRole;
 
@@ -577,13 +577,7 @@ export class SmartTerrain extends cse_alife_smart_zone implements ISimulationTar
 
     this.squadId = readIniNumber(this.ini, SMART_TERRAIN_SECTION, "squad_id", false, 0);
 
-    let respawnSectorData: Optional<string> = readIniString(
-      this.ini,
-      SMART_TERRAIN_SECTION,
-      "respawn_sector",
-      false,
-      ""
-    );
+    let respawnSectorData: Optional<string> = readIniString(this.ini, SMART_TERRAIN_SECTION, "respawn_sector", false);
 
     if (respawnSectorData !== null) {
       if (respawnSectorData === "default") {
@@ -602,35 +596,33 @@ export class SmartTerrain extends cse_alife_smart_zone implements ISimulationTar
       logger.info("Found no mutant point:", this.name());
     }
 
-    this.forbiddenPoint = readIniString(this.ini, SMART_TERRAIN_SECTION, "forbidden_point", false, "");
-    this.defendRestrictor = readIniString(this.ini, SMART_TERRAIN_SECTION, "def_restr", false, "", null);
-    this.attackRestrictor = readIniString(this.ini, SMART_TERRAIN_SECTION, "att_restr", false, "", null);
-    this.safeRestrictor = readIniString(this.ini, SMART_TERRAIN_SECTION, "safe_restr", false, "", null);
-    this.spawnPointName = readIniString(this.ini, SMART_TERRAIN_SECTION, "spawn_point", false, "");
+    this.forbiddenPoint = readIniString(this.ini, SMART_TERRAIN_SECTION, "forbidden_point", false);
+    this.defendRestrictor = readIniString(this.ini, SMART_TERRAIN_SECTION, "def_restr", false);
+    this.attackRestrictor = readIniString(this.ini, SMART_TERRAIN_SECTION, "att_restr", false);
+    this.safeRestrictor = readIniString(this.ini, SMART_TERRAIN_SECTION, "safe_restr", false);
+    this.spawnPointName = readIniString(this.ini, SMART_TERRAIN_SECTION, "spawn_point", false);
     this.arrivalDistance = readIniNumber(this.ini, SMART_TERRAIN_SECTION, "arrive_dist", false, 30);
 
-    const maxPopulationData: string = readIniString(this.ini, SMART_TERRAIN_SECTION, "max_population", false, "", "0");
+    const maxPopulationData: string = readIniString(
+      this.ini,
+      SMART_TERRAIN_SECTION,
+      "max_population",
+      false,
+      null,
+      "0"
+    );
     const parsedConditionsList: LuaArray<IConfigSwitchCondition> = parseConditionsList(maxPopulationData);
 
     this.maxPopulation = tonumber(pickSectionFromCondList(registry.actor, null, parsedConditionsList)) as TCount;
 
     this.isRespawnOnlySmart = readIniBoolean(this.ini, SMART_TERRAIN_SECTION, "respawn_only_smart", false, false);
 
-    const respawnSection: Optional<TSection> = readIniString(
-      this.ini,
-      SMART_TERRAIN_SECTION,
-      "respawn_params",
-      false,
-      "",
-      null
-    );
+    const respawnSection: Optional<TSection> = readIniString(this.ini, SMART_TERRAIN_SECTION, "respawn_params", false);
     const smartControlSection: Optional<TSection> = readIniString(
       this.ini,
       SMART_TERRAIN_SECTION,
       "smart_control",
-      false,
-      "",
-      null
+      false
     );
 
     if (smartControlSection !== null) {
@@ -1013,8 +1005,8 @@ export class SmartTerrain extends cse_alife_smart_zone implements ISimulationTar
         );
       }
 
-      const squadsCount: Optional<string> = readIniString(this.ini, sectionName, "spawn_num", false, "", null);
-      const squadsToSpawn: Optional<string> = readIniString(this.ini, sectionName, "spawn_squads", false, "", null);
+      const squadsCount: Optional<string> = readIniString(this.ini, sectionName, "spawn_num", false);
+      const squadsToSpawn: Optional<string> = readIniString(this.ini, sectionName, "spawn_squads", false);
 
       if (squadsToSpawn === null) {
         abort(

--- a/src/engine/core/objects/server/smart_terrain/SmartTerrainControl.ts
+++ b/src/engine/core/objects/server/smart_terrain/SmartTerrainControl.ts
@@ -43,13 +43,11 @@ export class SmartTerrainControl {
   public constructor(smartTerrain: SmartTerrain, ini: IniFile, section: TSection) {
     this.smartTerrain = smartTerrain;
 
-    this.noWeaponZone = readIniString(ini, section, "noweap_zone", true, "");
-    this.ignoreZone = readIniString(ini, section, "ignore_zone", false, "");
+    this.noWeaponZone = readIniString(ini, section, "noweap_zone", true);
+    this.ignoreZone = readIniString(ini, section, "ignore_zone", false);
 
-    this.alarmStartSoundConditionList = parseConditionsList(
-      readIniString(ini, section, "alarm_start_sound", false, "")
-    );
-    this.alarmStopSoundConditionList = parseConditionsList(readIniString(ini, section, "alarm_stop_sound", false, ""));
+    this.alarmStartSoundConditionList = parseConditionsList(readIniString(ini, section, "alarm_start_sound", false));
+    this.alarmStopSoundConditionList = parseConditionsList(readIniString(ini, section, "alarm_stop_sound", false));
   }
 
   /**

--- a/src/engine/core/objects/server/squad/Squad.ts
+++ b/src/engine/core/objects/server/squad/Squad.ts
@@ -339,17 +339,17 @@ export class Squad extends cse_alife_online_offline_group implements ISimulation
   public initialize(): void {
     const sectionName: TSection = this.section_name();
 
-    this.faction = readIniString(SYSTEM_INI, sectionName, "faction", true, "") as TCommunity;
+    this.faction = readIniString(SYSTEM_INI, sectionName, "faction", true) as TCommunity;
     this.actionConditionList = parseConditionsList(
-      readIniString(SYSTEM_INI, sectionName, "target_smart", false, "", "")
+      readIniString(SYSTEM_INI, sectionName, "target_smart", false, null, "")
     );
-    this.deathConditionList = parseConditionsList(readIniString(SYSTEM_INI, sectionName, "on_death", false, "", ""));
+    this.deathConditionList = parseConditionsList(readIniString(SYSTEM_INI, sectionName, "on_death", false, null, ""));
     this.invulnerability = parseConditionsList(
-      readIniString(SYSTEM_INI, sectionName, "invulnerability", false, "", "")
+      readIniString(SYSTEM_INI, sectionName, "invulnerability", false, null, "")
     );
-    this.relationship = this.relationship || readIniString(SYSTEM_INI, sectionName, "relationship", false, "", null);
+    this.relationship = this.relationship || readIniString(SYSTEM_INI, sectionName, "relationship", false);
     this.sympathy = readIniNumber(SYSTEM_INI, sectionName, "sympathy", false, null);
-    this.isSpotVisible = parseConditionsList(readIniString(SYSTEM_INI, sectionName, "show_spot", false, "", FALSE));
+    this.isSpotVisible = parseConditionsList(readIniString(SYSTEM_INI, sectionName, "show_spot", false, null, FALSE));
     this.isAlwaysArrived = readIniBoolean(SYSTEM_INI, sectionName, "always_arrived", false);
 
     this.setLocationTypesMaskFromSection("stalker_terrain");
@@ -362,7 +362,7 @@ export class Squad extends cse_alife_online_offline_group implements ISimulation
       this.section_name(),
       "behaviour",
       false,
-      "",
+      null,
       this.faction
     );
 
@@ -638,7 +638,7 @@ export class Squad extends cse_alife_online_offline_group implements ISimulation
       spawnSection,
       "custom_data",
       false,
-      "",
+      null,
       "misc\\default_custom_data.ltx"
     );
 
@@ -673,11 +673,11 @@ export class Squad extends cse_alife_online_offline_group implements ISimulation
     const sectionName: TName = this.section_name();
 
     const spawnSections: LuaArray<TSection> = parseStringsList(
-      readIniString(SYSTEM_INI, sectionName, "npc", false, "", "")
+      readIniString(SYSTEM_INI, sectionName, "npc", false, null, "")
     );
     const spawnPointData =
-      readIniString(SYSTEM_INI, sectionName, "spawn_point", false, "", "self") ||
-      readIniString(spawnSmartTerrain.ini, SMART_TERRAIN_SECTION, "spawn_point", false, "", "self");
+      readIniString(SYSTEM_INI, sectionName, "spawn_point", false, null, "self") ||
+      readIniString(spawnSmartTerrain.ini, SMART_TERRAIN_SECTION, "spawn_point", false, null, "self");
 
     const spawnPoint: Optional<TName> = pickSectionFromCondList(
       registry.actor,
@@ -715,7 +715,7 @@ export class Squad extends cse_alife_online_offline_group implements ISimulation
       }
     }
 
-    const randomSpawnConfig: Optional<string> = readIniString(SYSTEM_INI, sectionName, "npc_random", false, "", null);
+    const randomSpawnConfig: Optional<string> = readIniString(SYSTEM_INI, sectionName, "npc_random", false);
 
     if (randomSpawnConfig !== null) {
       const randomSpawn: LuaArray<string> = parseStringsList(randomSpawnConfig)!;

--- a/src/engine/core/objects/sounds/playable_sounds/AbstractPlayableSound.ts
+++ b/src/engine/core/objects/sounds/playable_sounds/AbstractPlayableSound.ts
@@ -29,7 +29,7 @@ export abstract class AbstractPlayableSound {
    * todo: Description.
    */
   public constructor(ini: IniFile, section: TSection) {
-    this.path = readIniString(ini, section, "path", true, "");
+    this.path = readIniString(ini, section, "path", true);
     this.section = section;
   }
 

--- a/src/engine/core/objects/sounds/playable_sounds/ActorSound.ts
+++ b/src/engine/core/objects/sounds/playable_sounds/ActorSound.ts
@@ -65,21 +65,21 @@ export class ActorSound extends AbstractPlayableSound {
 
     this.isStereo = readIniBoolean(ini, section, "actor_stereo", false, false);
     this.isPrefixed = readIniBoolean(ini, section, "npc_prefix", false, false);
-    this.shuffle = readIniString(ini, section, "shuffle", false, "", ESoundPlaylistType.RANDOM) as ESoundPlaylistType;
+    this.shuffle = readIniString(ini, section, "shuffle", false, null, ESoundPlaylistType.RANDOM) as ESoundPlaylistType;
     this.shouldPlayAlways = readIniBoolean(ini, section, "play_always", false, false);
 
     if (this.isPrefixed) {
       this.path = "characters_voice\\" + this.path;
     }
 
-    const interval = parseStringsList(readIniString(ini, section, "idle", false, "", "3,5,100"));
+    const interval = parseStringsList(readIniString(ini, section, "idle", false, null, "3,5,100"));
 
     this.minIdle = tonumber(interval.get(1))!;
     this.maxIdle = tonumber(interval.get(2))!;
     this.random = tonumber(interval.get(3))!;
-    this.faction = readIniString(ini, section, "faction", false, "", "");
-    this.point = readIniString(ini, section, "point", false, "", "");
-    this.message = readIniString(ini, section, "message", false, "", "");
+    this.faction = readIniString(ini, section, "faction", false, null, "");
+    this.point = readIniString(ini, section, "point", false, null, "");
+    this.message = readIniString(ini, section, "message", false, null, "");
 
     const fs: FS = getFS();
 

--- a/src/engine/core/objects/sounds/playable_sounds/NpcSound.ts
+++ b/src/engine/core/objects/sounds/playable_sounds/NpcSound.ts
@@ -91,7 +91,7 @@ export class NpcSound extends AbstractPlayableSound {
       section,
       "shuffle",
       false,
-      "",
+      null,
       ESoundPlaylistType.RANDOM
     ) as ESoundPlaylistType;
     this.isGroupSound = readIniBoolean(soundIni, section, "group_snd", false, false);
@@ -100,16 +100,16 @@ export class NpcSound extends AbstractPlayableSound {
     this.delay = readIniNumber(soundIni, section, "delay_sound", false, 0);
 
     const interval: LuaTable<number, string> = parseStringsList(
-      readIniString(soundIni, section, "idle", false, "", "3,5,100")
+      readIniString(soundIni, section, "idle", false, null, "3,5,100")
     );
 
     this.minIdle = tonumber(interval.get(1))!;
     this.maxIdle = tonumber(interval.get(2))!;
     this.random = tonumber(interval.get(3))!;
 
-    this.faction = readIniString(soundIni, section, "faction", false, "", "");
-    this.point = readIniString(soundIni, section, "point", false, "", "");
-    this.message = readIniString(soundIni, section, "message", false, "", "");
+    this.faction = readIniString(soundIni, section, "faction", false, null, "");
+    this.point = readIniString(soundIni, section, "point", false, null, "");
+    this.message = readIniString(soundIni, section, "message", false, null, "");
 
     const availableCommunities: LuaArray<TCommunity> = parseStringsList<TCommunity>(
       readIniString(
@@ -117,7 +117,7 @@ export class NpcSound extends AbstractPlayableSound {
         section,
         "avail_communities",
         false,
-        "",
+        null,
         string.format(
           "%s, %s, %s, %s, %s, %s, %s, %s, %s",
           communities.stalker,

--- a/src/engine/core/objects/sounds/playable_sounds/ObjectSound.ts
+++ b/src/engine/core/objects/sounds/playable_sounds/ObjectSound.ts
@@ -61,15 +61,15 @@ export class ObjectSound extends AbstractPlayableSound {
   public constructor(ini: IniFile, section: TSection) {
     super(ini, section);
 
-    const interval: LuaArray<string> = parseStringsList(readIniString(ini, section, "idle", false, "", "3,5,100"));
+    const interval: LuaArray<string> = parseStringsList(readIniString(ini, section, "idle", false, null, "3,5,100"));
 
-    this.shuffle = readIniString(ini, section, "shuffle", false, "", ESoundPlaylistType.RANDOM) as ESoundPlaylistType;
+    this.shuffle = readIniString(ini, section, "shuffle", false, null, ESoundPlaylistType.RANDOM) as ESoundPlaylistType;
     this.minIdle = tonumber(interval.get(1))!;
     this.maxIdle = tonumber(interval.get(2))!;
     this.rnd = tonumber(interval.get(3))!;
-    this.faction = readIniString(ini, section, "faction", false, "", "");
-    this.point = readIniString(ini, section, "point", false, "", "");
-    this.message = readIniString(ini, section, "message", false, "", "");
+    this.faction = readIniString(ini, section, "faction", false, null, "");
+    this.point = readIniString(ini, section, "point", false, null, "");
+    this.message = readIniString(ini, section, "message", false, null, "");
 
     const fs: FS = getFS();
 

--- a/src/engine/core/schemes/helicopter/heli_move/HeliCombat.ts
+++ b/src/engine/core/schemes/helicopter/heli_move/HeliCombat.ts
@@ -148,7 +148,7 @@ export class HeliCombat {
     this.combatUseRocket = readIniBoolean(ini, section, "combat_use_rocket", false, true);
     this.combatUseMgun = readIniBoolean(ini, section, "combat_use_mgun", false, true);
 
-    const combatIgnore: Optional<string> = readIniString(ini, section, "combat_ignore", false, "", null);
+    const combatIgnore: Optional<string> = readIniString(ini, section, "combat_ignore", false);
 
     if (combatIgnore !== null) {
       this.combatIgnore = parseConditionsList(combatIgnore);
@@ -156,7 +156,7 @@ export class HeliCombat {
       this.combatIgnore = null;
     }
 
-    const combaEnemy: Optional<string> = readIniString(ini, section, "combat_enemy", false, "", null);
+    const combaEnemy: Optional<string> = readIniString(ini, section, "combat_enemy", false);
 
     this.setEnemyFromCustomData(combaEnemy);
     this.maxVelocity = readIniNumber(ini, section, "combat_velocity", false, this.defaultVelocity);

--- a/src/engine/core/schemes/helicopter/heli_move/SchemeHelicopterMove.ts
+++ b/src/engine/core/schemes/helicopter/heli_move/SchemeHelicopterMove.ts
@@ -23,10 +23,10 @@ export class SchemeHelicopterMove extends AbstractScheme {
     const state: ISchemeHelicopterMoveState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.path_move = readIniString(ini, section, "path_move", true, "");
-    state.path_look = readIniString(ini, section, "path_look", false, "");
-    state.enemy_ = readIniString(ini, section, "enemy", false, "");
-    state.fire_point = readIniString(ini, section, "fire_point", false, "");
+    state.path_move = readIniString(ini, section, "path_move", true);
+    state.path_look = readIniString(ini, section, "path_look", false);
+    state.enemy_ = readIniString(ini, section, "enemy", false);
+    state.fire_point = readIniString(ini, section, "fire_point", false);
     state.max_velocity = readIniNumber(ini, section, "max_velocity", true, null) as number; // todo: Assert?
     state.max_mgun_dist = readIniNumber(ini, section, "max_mgun_attack_dist", false);
     state.max_rocket_dist = readIniNumber(ini, section, "max_rocket_attack_dist", false);

--- a/src/engine/core/schemes/monster/mob_home/SchemeMobHome.ts
+++ b/src/engine/core/schemes/monster/mob_home/SchemeMobHome.ts
@@ -21,7 +21,7 @@ export class SchemeMobHome extends AbstractScheme {
     ini: IniFile,
     scheme: EScheme,
     section: TSection,
-    pathPrefix: TName
+    smartTerrainName: TName
   ): void {
     logger.info("Activate scheme:", object.name(), scheme, section);
 
@@ -30,7 +30,7 @@ export class SchemeMobHome extends AbstractScheme {
     state.logic = getConfigSwitchConditions(ini, section);
 
     state.monsterState = getMonsterState(ini, section);
-    state.homeWayPoint = readIniString(ini, section, "path_home", false, pathPrefix, null);
+    state.homeWayPoint = readIniString(ini, section, "path_home", false, smartTerrainName);
 
     state.isSmartTerrainPoint = readIniBoolean(ini, section, "gulag_point", false, false);
     state.isAggressive = readIniBoolean(ini, section, "aggressive", false, false);

--- a/src/engine/core/schemes/monster/mob_jump/SchemeMobJump.ts
+++ b/src/engine/core/schemes/monster/mob_jump/SchemeMobJump.ts
@@ -7,7 +7,7 @@ import { parseStringsList } from "@/engine/core/utils/ini/ini_parse";
 import { readIniNumber, readIniString } from "@/engine/core/utils/ini/ini_read";
 import { LuaLogger } from "@/engine/core/utils/logging";
 import { createVector } from "@/engine/core/utils/vector";
-import { ClientObject, EScheme, ESchemeType, IniFile, LuaArray, TSection } from "@/engine/lib/types";
+import { ClientObject, EScheme, ESchemeType, IniFile, LuaArray, TName, TSection } from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename);
 
@@ -26,15 +26,15 @@ export class SchemeMobJump extends AbstractScheme {
     ini: IniFile,
     scheme: EScheme,
     section: TSection,
-    additional: string
+    smartTerrainName: TName
   ): void {
     const state: ISchemeMobJumpState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.jump_path_name = readIniString(ini, section, "path_jump", false, additional);
+    state.jump_path_name = readIniString(ini, section, "path_jump", false, smartTerrainName);
     state.ph_jump_factor = readIniNumber(ini, section, "ph_jump_factor", false, 1.8);
 
-    const offsetsData: string = readIniString(ini, section, "offset", true, "");
+    const offsetsData: string = readIniString(ini, section, "offset", true);
     const offsets: LuaArray<string> = parseStringsList(offsetsData);
 
     state.offset = createVector(tonumber(offsets.get(1))!, tonumber(offsets.get(2))!, tonumber(offsets.get(3))!);

--- a/src/engine/core/schemes/monster/mob_remark/SchemeMobRemark.ts
+++ b/src/engine/core/schemes/monster/mob_remark/SchemeMobRemark.ts
@@ -20,25 +20,19 @@ export class SchemeMobRemark extends AbstractScheme {
   /**
    * todo: Description.
    */
-  public static override activate(
-    object: ClientObject,
-    ini: IniFile,
-    scheme: EScheme,
-    section: TSection,
-    additional: string
-  ): void {
+  public static override activate(object: ClientObject, ini: IniFile, scheme: EScheme, section: TSection): void {
     const state: ISchemeMobRemarkState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
     state.state = getMonsterState(ini, section);
     state.dialog_cond = readIniConditionList(ini, section, "dialog_cond");
     state.no_reset = true;
-    state.anim = readIniString(ini, section, "anim", false, "");
+    state.anim = readIniString(ini, section, "anim", false);
     state.anim_movement = readIniBoolean(ini, section, "anim_movement", false, false);
-    state.anim_head = readIniString(ini, section, "anim_head", false, "");
-    state.tip = readIniString(ini, section, "tip", false, "");
-    state.snd = readIniString(ini, section, "snd", false, "");
-    state.time = readIniString(ini, section, "time", false, "");
+    state.anim_head = readIniString(ini, section, "anim_head", false);
+    state.tip = readIniString(ini, section, "tip", false);
+    state.snd = readIniString(ini, section, "snd", false);
+    state.time = readIniString(ini, section, "time", false);
   }
 
   /**

--- a/src/engine/core/schemes/object/ph_button/SchemePhysicalButton.ts
+++ b/src/engine/core/schemes/object/ph_button/SchemePhysicalButton.ts
@@ -23,7 +23,7 @@ export class SchemePhysicalButton extends AbstractScheme {
 
     state.logic = getConfigSwitchConditions(ini, section);
     state.on_press = readIniConditionList(ini, section, "on_press");
-    state.tooltip = readIniString(ini, section, "tooltip", false, "");
+    state.tooltip = readIniString(ini, section, "tooltip", false);
 
     if (state.tooltip) {
       object.set_tip_text(state.tooltip);
@@ -31,7 +31,7 @@ export class SchemePhysicalButton extends AbstractScheme {
       object.set_tip_text("");
     }
 
-    state.anim = readIniString(ini, section, "anim", true, "");
+    state.anim = readIniString(ini, section, "anim", true);
     state.blending = readIniBoolean(ini, section, "anim_blend", false, true);
     if (state.blending === null) {
       state.blending = true;

--- a/src/engine/core/schemes/object/ph_code/SchemeCode.ts
+++ b/src/engine/core/schemes/object/ph_code/SchemeCode.ts
@@ -28,7 +28,7 @@ export class SchemeCode extends AbstractScheme {
     const state: ISchemeCodeState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.tips = readIniString(ini, section, "tips", false, "", "st_codelock");
+    state.tips = readIniString(ini, section, "tips", false, null, "st_codelock");
 
     object.set_tip_text(state.tips);
 

--- a/src/engine/core/schemes/object/ph_door/SchemePhysicalDoor.ts
+++ b/src/engine/core/schemes/object/ph_door/SchemePhysicalDoor.ts
@@ -29,14 +29,14 @@ export class SchemePhysicalDoor extends AbstractScheme {
     state.no_force = readIniBoolean(ini, section, "no_force", false, false);
     state.not_for_npc = readIniBoolean(ini, section, "not_for_npc", false, false);
     state.show_tips = readIniBoolean(ini, section, "show_tips", false, true);
-    state.tip_open = readIniString(ini, section, "tip_open", false, "", "tip_door_open");
-    state.tip_unlock = readIniString(ini, section, "tip_open", false, "", "tip_door_locked");
-    state.tip_close = readIniString(ini, section, "tip_close", false, "", "tip_door_close");
+    state.tip_open = readIniString(ini, section, "tip_open", false, null, "tip_door_open");
+    state.tip_unlock = readIniString(ini, section, "tip_open", false, null, "tip_door_locked");
+    state.tip_close = readIniString(ini, section, "tip_close", false, null, "tip_door_close");
     state.slider = readIniBoolean(ini, section, "slider", false, false);
     // -- st.snd_init = getConfigString(ini, section, "snd_init", object, false, "")
-    state.snd_open_start = readIniString(ini, section, "snd_open_start", false, "", "trader_door_open_start");
-    state.snd_close_start = readIniString(ini, section, "snd_close_start", false, "", "trader_door_close_start");
-    state.snd_close_stop = readIniString(ini, section, "snd_close_stop", false, "", "trader_door_close_stop");
+    state.snd_open_start = readIniString(ini, section, "snd_open_start", false, null, "trader_door_open_start");
+    state.snd_close_start = readIniString(ini, section, "snd_close_start", false, null, "trader_door_close_start");
+    state.snd_close_stop = readIniString(ini, section, "snd_close_stop", false, null, "trader_door_close_stop");
     state.on_use = readIniConditionList(ini, section, "on_use");
 
     if (state.locked === true || state.not_for_npc === true) {
@@ -49,7 +49,7 @@ export class SchemePhysicalDoor extends AbstractScheme {
       }
     }
 
-    state.hit_on_bone = parseBoneStateDescriptors(readIniString(ini, section, "hit_on_bone", false, ""));
+    state.hit_on_bone = parseBoneStateDescriptors(readIniString(ini, section, "hit_on_bone", false));
   }
 
   /**

--- a/src/engine/core/schemes/object/ph_force/SchemePhysicalForce.ts
+++ b/src/engine/core/schemes/object/ph_force/SchemePhysicalForce.ts
@@ -29,7 +29,7 @@ export class SchemePhysicalForce extends AbstractScheme {
     state.time = readIniNumber(ini, section, "time", true, 0);
     state.delay = readIniNumber(ini, section, "delay", false, 0);
 
-    const path_name = readIniString(ini, section, "point", true, "");
+    const path_name = readIniString(ini, section, "point", true);
     const index = readIniNumber(ini, section, "point_index", false, 0);
 
     if (state.force === null || state.force <= 0) {

--- a/src/engine/core/schemes/object/ph_hit/SchemePhysicalHit.ts
+++ b/src/engine/core/schemes/object/ph_hit/SchemePhysicalHit.ts
@@ -24,8 +24,8 @@ export class SchemePhysicalHit extends AbstractScheme {
     state.logic = getConfigSwitchConditions(ini, section);
     state.power = readIniNumber(ini, section, "power", false, 0);
     state.impulse = readIniNumber(ini, section, "impulse", false, 1000);
-    state.bone = readIniString(ini, section, "bone", true, "");
-    state.dir_path = readIniString(ini, section, "dir_path", true, "");
+    state.bone = readIniString(ini, section, "bone", true);
+    state.dir_path = readIniString(ini, section, "dir_path", true);
   }
 
   /**

--- a/src/engine/core/schemes/object/ph_idle/SchemePhysicalIdle.ts
+++ b/src/engine/core/schemes/object/ph_idle/SchemePhysicalIdle.ts
@@ -24,10 +24,10 @@ export class SchemePhysicalIdle extends AbstractScheme {
     const state: ISchemePhysicalIdleState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.bonesHitCondlists = parseBoneStateDescriptors(readIniString(ini, section, "hit_on_bone", false, ""));
+    state.bonesHitCondlists = parseBoneStateDescriptors(readIniString(ini, section, "hit_on_bone", false));
     state.isNonscriptUsable = readIniBoolean(ini, section, "nonscript_usable", false);
     state.onUse = readIniConditionList(ini, section, "on_use");
-    state.tip = readIniString(ini, section, "tips", false, "", "");
+    state.tip = readIniString(ini, section, "tips", false, null, "");
 
     object.set_tip_text(state.tip);
   }

--- a/src/engine/core/schemes/object/ph_minigun/SchemeMinigun.ts
+++ b/src/engine/core/schemes/object/ph_minigun/SchemeMinigun.ts
@@ -9,7 +9,7 @@ import {
   readIniStringAndCondList,
 } from "@/engine/core/utils/ini/ini_read";
 import { LuaLogger } from "@/engine/core/utils/logging";
-import { ClientObject, EScheme, ESchemeType, IniFile, TSection } from "@/engine/lib/types";
+import { ClientObject, EScheme, ESchemeType, IniFile, TName, TSection } from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename);
 
@@ -33,17 +33,17 @@ export class SchemeMinigun extends AbstractScheme {
     ini: IniFile,
     scheme: EScheme,
     section: TSection,
-    additional: string
+    smartTerrainName: TName
   ): void {
     const state: ISchemeMinigunState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.path_fire = readIniString(ini, section, "path_fire", false, additional, null);
+    state.path_fire = readIniString(ini, section, "path_fire", false, smartTerrainName);
     state.auto_fire = readIniBoolean(ini, section, "auto_fire", false, false);
     state.fire_time = readIniNumber(ini, section, "fire_time", false, DEF_MIN_FIRE_TIME);
     state.fire_rep = readIniNumber(ini, section, "fire_repeat", false, DEF_FIRE_REP);
     state.fire_range = readIniNumber(ini, section, "fire_range", false, DEF_FIRE_RANGE);
-    state.fire_target = readIniString(ini, section, "target", false, additional, "points");
+    state.fire_target = readIniString(ini, section, "target", false, smartTerrainName, "points");
     state.fire_track_target = readIniBoolean(ini, section, "track_target", false, false);
     state.fire_angle = readIniNumber(ini, section, "fire_angle", false, DEF_FIRE_ANGLE);
     state.shoot_only_on_visible = readIniBoolean(ini, section, "shoot_only_on_visible", false, true);

--- a/src/engine/core/schemes/object/ph_oscillate/SchemeOscillate.ts
+++ b/src/engine/core/schemes/object/ph_oscillate/SchemeOscillate.ts
@@ -24,12 +24,12 @@ export class SchemeOscillate extends AbstractScheme {
     ini: IniFile,
     scheme: EScheme,
     section: TSection,
-    gulagName: TName
+    smartTerrainName: TName
   ): void {
     const state: ISchemeOscillateState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.joint = readIniString(ini, section, "joint", true, gulagName);
+    state.joint = readIniString(ini, section, "joint", true, smartTerrainName);
 
     if (state.joint === null) {
       abort("Invalid joint definition for object %s", object.name());

--- a/src/engine/core/schemes/restrictor/sr_crow_spawner/SchemeCrowSpawner.ts
+++ b/src/engine/core/schemes/restrictor/sr_crow_spawner/SchemeCrowSpawner.ts
@@ -25,7 +25,7 @@ export class SchemeCrowSpawner extends AbstractScheme {
 
     state.logic = getConfigSwitchConditions(ini, section);
     state.maxCrowsOnLevel = readIniNumber(ini, section, "max_crows_on_level", false, 16);
-    state.pathsList = parseStringsList(readIniString<TName>(ini, section, "spawn_path", false, "", ""));
+    state.pathsList = parseStringsList(readIniString<TName>(ini, section, "spawn_path", false, null, ""));
   }
 
   /**

--- a/src/engine/core/schemes/restrictor/sr_cutscene/SchemeCutscene.ts
+++ b/src/engine/core/schemes/restrictor/sr_cutscene/SchemeCutscene.ts
@@ -24,11 +24,11 @@ export class SchemeCutscene extends AbstractScheme {
     const state: ISchemeCutsceneState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.point = readIniString(ini, section, "point", true, "", "none");
-    state.look = readIniString(ini, section, "look", true, "", "none");
+    state.point = readIniString(ini, section, "point", true, null, "none");
+    state.look = readIniString(ini, section, "look", true, null, "none");
     state.isGlobalCameraEffect = readIniBoolean(ini, section, "global_cameffect", false, false);
-    state.ppEffector = readIniString(ini, section, "pp_effector", false, "", NIL) + ".ppe";
-    state.cameraEffector = parseStringsList(readIniString(ini, section, "cam_effector", true, ""));
+    state.ppEffector = readIniString(ini, section, "pp_effector", false, null, NIL) + ".ppe";
+    state.cameraEffector = parseStringsList(readIniString(ini, section, "cam_effector", true));
     state.fov = readIniNumber(ini, section, "fov", false);
     state.shouldEnableUiOnEnd = readIniBoolean(ini, section, "enable_ui_on_end", false, true);
     state.isOutdoor = readIniBoolean(ini, section, "outdoor", false, false);

--- a/src/engine/core/schemes/restrictor/sr_deimos/SchemeDeimos.ts
+++ b/src/engine/core/schemes/restrictor/sr_deimos/SchemeDeimos.ts
@@ -28,11 +28,11 @@ export class SchemeDeimos extends AbstractScheme {
     state.growing_koef = readIniNumber(ini, section, "growing_koef", false, 0.1);
     state.lowering_koef = readIniNumber(ini, section, "lowering_koef", false, state.growing_koef);
     state.pp_effector = readIniString(ini, section, "pp_effector", false, null);
-    state.cam_effector = readIniString(ini, section, "cam_effector", false, "");
-    state.pp_effector2 = readIniString(ini, section, "pp_effector2", false, "");
+    state.cam_effector = readIniString(ini, section, "cam_effector", false);
+    state.pp_effector2 = readIniString(ini, section, "pp_effector2", false);
     state.cam_effector_repeating_time = readIniNumber(ini, section, "cam_effector_repeating_time", false, 10) * 1000;
-    state.noise_sound = readIniString(ini, section, "noise_sound", false, "");
-    state.heartbeet_sound = readIniString(ini, section, "heartbeet_sound", false, "");
+    state.noise_sound = readIniString(ini, section, "noise_sound", false);
+    state.heartbeet_sound = readIniString(ini, section, "heartbeet_sound", false);
     state.health_lost = readIniNumber(ini, section, "health_lost", false, 0.01);
     state.disable_bound = readIniNumber(ini, section, "disable_bound", false, 0.1);
     state.switch_lower_bound = readIniNumber(ini, section, "switch_lower_bound", false, 0.5);

--- a/src/engine/core/schemes/restrictor/sr_monster/SchemeMonster.ts
+++ b/src/engine/core/schemes/restrictor/sr_monster/SchemeMonster.ts
@@ -24,12 +24,12 @@ export class SchemeMonster extends AbstractScheme {
     const state: ISchemeMonsterState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.snd_obj = readIniString(ini, section, "snd", false, "", null);
+    state.snd_obj = readIniString(ini, section, "snd", false);
     state.delay = readIniNumber(ini, section, "delay", false, 0);
     state.idle = readIniNumber(ini, section, "idle", false, 30) * 10000;
 
-    state.path_table = parseStringsList(readIniString(ini, section, "sound_path", false, "", null)!);
-    state.monster = readIniString(ini, section, "monster_section", false, "", null);
+    state.path_table = parseStringsList(readIniString(ini, section, "sound_path", false)!);
+    state.monster = readIniString(ini, section, "monster_section", false);
     state.sound_slide_vel = readIniNumber(ini, section, "slide_velocity", false, 7);
   }
 

--- a/src/engine/core/schemes/restrictor/sr_particle/SchemeParticle.ts
+++ b/src/engine/core/schemes/restrictor/sr_particle/SchemeParticle.ts
@@ -23,8 +23,8 @@ export class SchemeParticle extends AbstractScheme {
     const state: ISchemeParticleState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.name = readIniString(ini, section, "name", true, "");
-    state.path = readIniString(ini, section, "path", true, "");
+    state.name = readIniString(ini, section, "name", true);
+    state.path = readIniString(ini, section, "path", true);
     state.mode = readIniNumber(ini, section, "mode", true);
     state.looped = readIniBoolean(ini, section, "looped", false);
 

--- a/src/engine/core/schemes/restrictor/sr_psy_antenna/SchemePsyAntenna.ts
+++ b/src/engine/core/schemes/restrictor/sr_psy_antenna/SchemePsyAntenna.ts
@@ -24,13 +24,13 @@ export class SchemePsyAntenna extends AbstractScheme {
 
     state.logic = getConfigSwitchConditions(ini, section);
     state.intensity = readIniNumber(ini, section, "eff_intensity", true) * 0.01;
-    state.postprocess = readIniString(ini, section, "postprocess", false, "", postProcessors.psy_antenna);
+    state.postprocess = readIniString(ini, section, "postprocess", false, null, postProcessors.psy_antenna);
     state.hit_intensity = readIniNumber(ini, section, "hit_intensity", true) * 0.01;
     state.phantom_prob = readIniNumber(ini, section, "phantom_prob", false, 0) * 0.01;
     state.mute_sound_threshold = readIniNumber(ini, section, "mute_sound_threshold", false, 0);
     state.no_static = readIniBoolean(ini, section, "no_static", false, false);
     state.no_mumble = readIniBoolean(ini, section, "no_mumble", false, false);
-    state.hit_type = readIniString(ini, section, "hit_type", false, "", "wound");
+    state.hit_type = readIniString(ini, section, "hit_type", false, null, "wound");
     state.hit_freq = readIniNumber(ini, section, "hit_freq", false, 5000);
   }
 

--- a/src/engine/core/schemes/restrictor/sr_teleport/SchemeTeleport.ts
+++ b/src/engine/core/schemes/restrictor/sr_teleport/SchemeTeleport.ts
@@ -31,8 +31,8 @@ export class SchemeTeleport extends AbstractScheme {
 
     for (const it of $range(1, 10)) {
       const teleportPoint: ITeleportPoint = {
-        point: readIniString(ini, section, "point" + tostring(it), false, "", "none"),
-        look: readIniString(ini, section, "look" + tostring(it), false, "", "none"),
+        point: readIniString(ini, section, "point" + tostring(it), false, null, "none"),
+        look: readIniString(ini, section, "look" + tostring(it), false, null, "none"),
         probability: readIniNumber(ini, section, "prob" + tostring(it), false, 100),
       };
 

--- a/src/engine/core/schemes/restrictor/sr_timer/SchemeTimer.ts
+++ b/src/engine/core/schemes/restrictor/sr_timer/SchemeTimer.ts
@@ -26,7 +26,7 @@ export class SchemeTimer extends AbstractScheme {
     const state: ISchemeTimerState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.type = readIniString<ETimerType>(ini, section, "type", false, "", ETimerType.INCREMENT) as ETimerType;
+    state.type = readIniString<ETimerType>(ini, section, "type", false, null, ETimerType.INCREMENT) as ETimerType;
 
     assert(
       state.type === ETimerType.INCREMENT || state.type === ETimerType.DECREMENT,
@@ -42,8 +42,8 @@ export class SchemeTimer extends AbstractScheme {
     }
 
     state.onValue = readIniNumberAndConditionList(ini, section, "on_value");
-    state.timerId = readIniString(ini, section, "timer_id", false, "", "hud_timer");
-    state.string = readIniString(ini, section, "string", false, "");
+    state.timerId = readIniString(ini, section, "timer_id", false, null, "hud_timer");
+    state.string = readIniString(ini, section, "string", false);
   }
 
   /**

--- a/src/engine/core/schemes/stalker/animpoint/SchemeAnimpoint.ts
+++ b/src/engine/core/schemes/stalker/animpoint/SchemeAnimpoint.ts
@@ -35,21 +35,21 @@ export class SchemeAnimpoint extends AbstractScheme {
     const state: ISchemeAnimpointState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.coverName = readIniString(ini, section, "cover_name", false, "", "$script_id$_cover");
+    state.coverName = readIniString(ini, section, "cover_name", false, null, "$script_id$_cover");
     state.useCamp = readIniBoolean(ini, section, "use_camp", false, true);
     state.reachMovement = readIniString<EStalkerState>(
       ini,
       section,
       "reach_movement",
       false,
-      "",
+      null,
       EStalkerState.WALK
     ) as EStalkerState;
 
     state.reachDistanceSqr = readIniNumber(ini, section, "reach_distance", false, 0.75);
     state.reachDistanceSqr *= state.reachDistanceSqr; // Calculate for sqr comparison.
 
-    const rawAvailableAnimations: Optional<string> = readIniString(ini, section, "avail_animations", false, "", null);
+    const rawAvailableAnimations: Optional<string> = readIniString(ini, section, "avail_animations", false);
 
     state.availableAnimations = rawAvailableAnimations === null ? null : parseStringsList(rawAvailableAnimations);
   }

--- a/src/engine/core/schemes/stalker/camper/SchemeCamper.ts
+++ b/src/engine/core/schemes/stalker/camper/SchemeCamper.ts
@@ -49,8 +49,8 @@ export class SchemeCamper extends AbstractScheme {
 
     state.sniper = readIniBoolean(ini, section, "sniper", false);
     state.no_retreat = readIniBoolean(ini, section, "no_retreat", false);
-    state.shoot = readIniString(ini, section, "shoot", false, "", "always");
-    state.sniper_anim = readIniString(ini, section, "sniper_anim", false, "hide_na");
+    state.shoot = readIniString(ini, section, "shoot", false, null, "always");
+    state.sniper_anim = readIniString(ini, section, "sniper_anim", false, null, "hide_na");
 
     if (state.sniper === true && state.no_retreat === true) {
       abort("ERROR: NPC [%s] Section [%s]. No_retreat not available for SNIPER.", object.name(), section);
@@ -69,12 +69,12 @@ export class SchemeCamper extends AbstractScheme {
       moving: readIniString(ini, section, "def_state_moving", false),
       moving_fire: readIniString(ini, section, "def_state_moving_fire", false),
       campering: campering,
-      standing: readIniString(ini, section, "def_state_standing", false, "", campering),
+      standing: readIniString(ini, section, "def_state_standing", false, null, campering),
       campering_fire: readIniString(ini, section, "def_state_campering_fire", false) as EStalkerState,
     };
 
     state.scantime_free = readIniNumber(ini, section, "scantime_free", false, 60_000);
-    state.attack_sound = readIniString(ini, section, "attack_sound", false, "", "fight_attack");
+    state.attack_sound = readIniString(ini, section, "attack_sound", false, null, "fight_attack");
 
     if (state.attack_sound === FALSE) {
       state.attack_sound = null;

--- a/src/engine/core/schemes/stalker/cover/SchemeCover.ts
+++ b/src/engine/core/schemes/stalker/cover/SchemeCover.ts
@@ -33,9 +33,9 @@ export class SchemeCover extends AbstractScheme {
     const state: ISchemeCoverState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.smartTerrainName = readIniString(ini, section, "smart", false, "");
-    state.animationConditionList = parseConditionsList(readIniString(ini, section, "anim", false, "", "hide"));
-    state.soundIdle = readIniString(ini, section, "sound_idle", false, "");
+    state.smartTerrainName = readIniString(ini, section, "smart", false);
+    state.animationConditionList = parseConditionsList(readIniString(ini, section, "anim", false, null, "hide"));
+    state.soundIdle = readIniString(ini, section, "sound_idle", false);
 
     assertDefined(state.smartTerrainName, "There is no path_walk and smart in ActionCover.");
 

--- a/src/engine/core/schemes/stalker/death/SchemeDeath.ts
+++ b/src/engine/core/schemes/stalker/death/SchemeDeath.ts
@@ -50,9 +50,7 @@ export class SchemeDeath extends AbstractScheme {
       objectState.ini!,
       objectState.sectionLogic,
       "on_death",
-      false,
-      "",
-      null
+      false
     );
 
     if (deathSection !== null) {
@@ -63,13 +61,13 @@ export class SchemeDeath extends AbstractScheme {
       }
 
       const state: ISchemeDeathState = objectState[SchemeDeath.SCHEME_SECTION] as ISchemeDeathState;
-      const onInfo: Optional<string> = readIniString(objectState.ini!, deathSection, "on_info", false, "", null);
+      const onInfo: Optional<string> = readIniString(objectState.ini!, deathSection, "on_info", false);
 
       if (onInfo !== null) {
         state!.info = parseConditionsList(onInfo);
       }
 
-      const onInfo2: Optional<string> = readIniString(objectState.ini!, deathSection, "on_info2", false, "", null);
+      const onInfo2: Optional<string> = readIniString(objectState.ini!, deathSection, "on_info2", false);
 
       if (onInfo2 !== null) {
         state!.info2 = parseConditionsList(onInfo2);

--- a/src/engine/core/schemes/stalker/meet/utils/meet_initialize.ts
+++ b/src/engine/core/schemes/stalker/meet/utils/meet_initialize.ts
@@ -64,47 +64,51 @@ export function initializeMeetScheme(
     const defaults = relation === EClientObjectRelation.ENEMY ? meetEnemyDefaults : meetNeutralDefaults;
 
     state.closeDistance = parseConditionsList(
-      readIniString(ini, section, "close_distance", false, "", defaults.closeDistance)
+      readIniString(ini, section, "close_distance", false, null, defaults.closeDistance)
     );
     state.closeAnimation = parseConditionsList(
-      readIniString(ini, section, "close_anim", false, "", defaults.closeAnimation)
+      readIniString(ini, section, "close_anim", false, null, defaults.closeAnimation)
     );
     state.closeSoundDistance = parseConditionsList(
-      readIniString(ini, section, "close_snd_distance", false, "", defaults.closeDistance)
+      readIniString(ini, section, "close_snd_distance", false, null, defaults.closeDistance)
     );
     state.closeSoundHello = parseConditionsList(
-      readIniString(ini, section, "close_snd_hello", false, "", defaults.closeSoundHello)
+      readIniString(ini, section, "close_snd_hello", false, null, defaults.closeSoundHello)
     );
     state.closeSoundBye = parseConditionsList(
-      readIniString(ini, section, "close_snd_bye", false, "", defaults.closeSoundBye)
+      readIniString(ini, section, "close_snd_bye", false, null, defaults.closeSoundBye)
     );
     state.closeVictim = parseConditionsList(
-      readIniString(ini, section, "close_victim", false, "", defaults.closeVictim)
+      readIniString(ini, section, "close_victim", false, null, defaults.closeVictim)
     );
 
     state.farDistance = parseConditionsList(
-      readIniString(ini, section, "far_distance", false, "", defaults.farDistance)
+      readIniString(ini, section, "far_distance", false, null, defaults.farDistance)
     );
-    state.farAnimation = parseConditionsList(readIniString(ini, section, "far_anim", false, "", defaults.farAnimation));
+    state.farAnimation = parseConditionsList(
+      readIniString(ini, section, "far_anim", false, null, defaults.farAnimation)
+    );
     state.farSoundDistance = parseConditionsList(
-      readIniString(ini, section, "far_snd_distance", false, "", defaults.farSoundDistance)
+      readIniString(ini, section, "far_snd_distance", false, null, defaults.farSoundDistance)
     );
-    state.farSound = parseConditionsList(readIniString(ini, section, "far_snd", false, "", defaults.farSound));
-    state.farVictim = parseConditionsList(readIniString(ini, section, "far_victim", false, "", defaults.farVictim));
+    state.farSound = parseConditionsList(readIniString(ini, section, "far_snd", false, null, defaults.farSound));
+    state.farVictim = parseConditionsList(readIniString(ini, section, "far_victim", false, null, defaults.farVictim));
 
-    state.useSound = parseConditionsList(readIniString(ini, section, "snd_on_use", false, "", defaults.useSound));
-    state.use = parseConditionsList(readIniString(ini, section, "use", false, "", defaults.use));
-    state.meetDialog = parseConditionsList(readIniString(ini, section, "meet_dialog", false, "", defaults.meetDialog));
-    state.abuse = parseConditionsList(readIniString(ini, section, "abuse", false, "", defaults.abuse));
+    state.useSound = parseConditionsList(readIniString(ini, section, "snd_on_use", false, null, defaults.useSound));
+    state.use = parseConditionsList(readIniString(ini, section, "use", false, null, defaults.use));
+    state.meetDialog = parseConditionsList(
+      readIniString(ini, section, "meet_dialog", false, null, defaults.meetDialog)
+    );
+    state.abuse = parseConditionsList(readIniString(ini, section, "abuse", false, null, defaults.abuse));
     state.isTradeEnabled = parseConditionsList(
-      readIniString(ini, section, "trade_enable", false, "", defaults.isTradeEnabled)
+      readIniString(ini, section, "trade_enable", false, null, defaults.isTradeEnabled)
     );
     state.isBreakAllowed = parseConditionsList(
-      readIniString(ini, section, "allow_break", false, "", defaults.isBreakAllowed)
+      readIniString(ini, section, "allow_break", false, null, defaults.isBreakAllowed)
     );
     state.isMeetOnTalking =
-      readIniString(ini, section, "meet_on_talking", false, "", defaults.isMeetOnTalking) === TRUE;
-    state.useText = parseConditionsList(readIniString(ini, section, "use_text", false, "", defaults.useText));
+      readIniString(ini, section, "meet_on_talking", false, null, defaults.isMeetOnTalking) === TRUE;
+    state.useText = parseConditionsList(readIniString(ini, section, "use_text", false, null, defaults.useText));
 
     state.resetDistance = logicsConfig.MEET_RESET_DISTANCE;
     state.isMeetOnlyAtPathEnabled = true;

--- a/src/engine/core/schemes/stalker/patrol/SchemePatrol.ts
+++ b/src/engine/core/schemes/stalker/patrol/SchemePatrol.ts
@@ -34,14 +34,14 @@ export class SchemePatrol extends AbstractScheme {
     ini: IniFile,
     scheme: EScheme,
     section: TSection,
-    gulagName: TName
+    smartTerrainName: TName
   ): void {
     const state: ISchemePatrolState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.path_name = readIniString(ini, section, "path_walk", true, gulagName);
+    state.path_name = readIniString(ini, section, "path_walk", true, smartTerrainName);
     state.path_walk = state.path_name;
-    state.path_look = readIniString(ini, section, "path_look", false, gulagName);
+    state.path_look = readIniString(ini, section, "path_look", false, smartTerrainName);
 
     if (state.path_walk === state.path_look) {
       abort(
@@ -51,26 +51,26 @@ export class SchemePatrol extends AbstractScheme {
       );
     }
 
-    state.formation = readIniString(ini, section, "formation", false, "");
+    state.formation = readIniString(ini, section, "formation", false);
     state.silent = readIniBoolean(ini, section, "silent", false, false);
     if (state.formation === null) {
       state.formation = "back";
     }
 
-    state.move_type = readIniString(ini, section, "move_type", false, "");
+    state.move_type = readIniString(ini, section, "move_type", false);
     if (state.move_type === null) {
       state.move_type = "patrol";
     }
 
     state.suggested_state = {} as any;
-    state.suggested_state.standing = readIniString(ini, section, "def_state_standing", false, "");
-    state.suggested_state.moving = readIniString(ini, section, "def_state_moving1", false, "");
+    state.suggested_state.standing = readIniString(ini, section, "def_state_standing", false);
+    state.suggested_state.moving = readIniString(ini, section, "def_state_moving1", false);
     state.suggested_state.moving = readIniString(
       ini,
       section,
       "def_state_moving",
       false,
-      "",
+      null,
       state.suggested_state.moving
     );
     state.path_walk_info = null;

--- a/src/engine/core/schemes/stalker/remark/SchemeRemark.ts
+++ b/src/engine/core/schemes/stalker/remark/SchemeRemark.ts
@@ -36,15 +36,15 @@ export class SchemeRemark extends AbstractScheme {
 
     state.logic = getConfigSwitchConditions(ini, section);
     state.snd_anim_sync = readIniBoolean(ini, section, "snd_anim_sync", false);
-    state.snd = readIniString(ini, section, "snd", false, "", null);
-    state.anim = parseConditionsList(readIniString(ini, section, "anim", false, "", "wait"));
-    state.tips_id = readIniString(ini, section, "tips", false, "");
+    state.snd = readIniString(ini, section, "snd", false);
+    state.anim = parseConditionsList(readIniString(ini, section, "anim", false, null, "wait"));
+    state.tips_id = readIniString(ini, section, "tips", false);
 
     if (state.tips_id !== null) {
-      state.sender = readIniString(ini, section, "tips_sender", false, "");
+      state.sender = readIniString(ini, section, "tips_sender", false);
     }
 
-    state.target = readIniString(ini, section, "target", false, "", NIL);
+    state.target = readIniString(ini, section, "target", false, null, NIL);
     state.target_id = null;
     state.target_position = null;
   }

--- a/src/engine/core/schemes/stalker/remark/actions/ActionRemarkActivity.ts
+++ b/src/engine/core/schemes/stalker/remark/actions/ActionRemarkActivity.ts
@@ -255,8 +255,8 @@ export function initTarget(
       isTargetInitialized = true;
     }
   } else if (targetType === "job") {
-    const [job, gulag] = parseTarget(target);
-    const smartTerrain: SmartTerrain = SimulationBoardManager.getInstance().getSmartTerrainByName(gulag!)!;
+    const [job, smartTerrainName] = parseTarget(target);
+    const smartTerrain: SmartTerrain = SimulationBoardManager.getInstance().getSmartTerrainByName(smartTerrainName!)!;
 
     targetId = smartTerrain.getObjectIdByJobSection(job!);
     isTargetInitialized = targetId !== null && true;

--- a/src/engine/core/schemes/stalker/sleeper/SchemeSleeper.ts
+++ b/src/engine/core/schemes/stalker/sleeper/SchemeSleeper.ts
@@ -9,7 +9,7 @@ import { getConfigSwitchConditions } from "@/engine/core/utils/ini/ini_config";
 import { readIniBoolean, readIniString } from "@/engine/core/utils/ini/ini_read";
 import { LuaLogger } from "@/engine/core/utils/logging";
 import { addCommonActionPreconditions } from "@/engine/core/utils/scheme/scheme_setup";
-import { ActionPlanner, ClientObject, IniFile } from "@/engine/lib/types";
+import { ActionPlanner, ClientObject, IniFile, TName } from "@/engine/lib/types";
 import { EScheme, ESchemeType, TSection } from "@/engine/lib/types/scheme";
 
 const logger: LuaLogger = new LuaLogger($filename);
@@ -29,12 +29,12 @@ export class SchemeSleeper extends AbstractScheme {
     ini: IniFile,
     scheme: EScheme,
     section: TSection,
-    additional: string
+    smartTerrainName: TName
   ): void {
     const state: ISchemeSleeperState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.path_main = readIniString(ini, section, "path_main", true, additional);
+    state.path_main = readIniString(ini, section, "path_main", true, smartTerrainName);
     state.wakeable = readIniBoolean(ini, section, "wakeable", false);
     state.path_walk = null;
     state.path_walk_info = null;

--- a/src/engine/core/schemes/stalker/smartcover/SchemeSmartCover.ts
+++ b/src/engine/core/schemes/stalker/smartcover/SchemeSmartCover.ts
@@ -34,20 +34,20 @@ export class SchemeSmartCover extends AbstractScheme {
     const state: ISchemeSmartCoverState = AbstractScheme.assign(object, ini, scheme, section);
 
     state.logic = getConfigSwitchConditions(ini, section);
-    state.cover_name = readIniString(ini, section, "cover_name", false, "", "$script_id$_cover");
-    state.loophole_name = readIniString(ini, section, "loophole_name", false, "", null);
-    state.cover_state = readIniString(ini, section, "cover_state", false, "", "default_behaviour");
-    state.target_enemy = readIniString(ini, section, "target_enemy", false, "", null);
-    state.target_path = readIniString(ini, section, "target_path", false, "", NIL);
+    state.cover_name = readIniString(ini, section, "cover_name", false, null, "$script_id$_cover");
+    state.loophole_name = readIniString(ini, section, "loophole_name", false);
+    state.cover_state = readIniString(ini, section, "cover_state", false, null, "default_behaviour");
+    state.target_enemy = readIniString(ini, section, "target_enemy", false);
+    state.target_path = readIniString(ini, section, "target_path", false, null, NIL);
     state.idle_min_time = readIniNumber(ini, section, "idle_min_time", false, 6);
     state.idle_max_time = readIniNumber(ini, section, "idle_max_time", false, 10);
     state.lookout_min_time = readIniNumber(ini, section, "lookout_min_time", false, 6);
     state.lookout_max_time = readIniNumber(ini, section, "lookout_max_time", false, 10);
-    state.exit_body_state = readIniString(ini, section, "exit_body_state", false, "", "stand");
+    state.exit_body_state = readIniString(ini, section, "exit_body_state", false, null, "stand");
     state.use_precalc_cover = readIniBoolean(ini, section, "use_precalc_cover", false, false);
     state.use_in_combat = readIniBoolean(ini, section, "use_in_combat", false, false);
     state.weapon_type = readIniString(ini, section, "weapon_type", false);
-    state.moving = readIniString(ini, section, "def_state_moving", false, "", "sneak");
+    state.moving = readIniString(ini, section, "def_state_moving", false, null, "sneak");
     state.sound_idle = readIniString(ini, section, "sound_idle", false);
   }
 

--- a/src/engine/core/schemes/stalker/walker/SchemeWalker.ts
+++ b/src/engine/core/schemes/stalker/walker/SchemeWalker.ts
@@ -49,17 +49,17 @@ export class SchemeWalker extends AbstractScheme {
     );
 
     state.team = readIniString(ini, section, "team", false, smartTerrain);
-    state.sound_idle = readIniString(ini, section, "sound_idle", false, "");
+    state.sound_idle = readIniString(ini, section, "sound_idle", false);
     state.use_camp = readIniBoolean(ini, section, "use_camp", false, false);
 
-    const baseMoving: EStalkerState = readIniString(ini, section, "def_state_moving1", false, "");
+    const baseMoving: EStalkerState = readIniString(ini, section, "def_state_moving1", false);
 
     state.suggested_state = {
       campering: null,
       campering_fire: null,
       moving_fire: null,
-      standing: readIniString(ini, section, "def_state_standing", false, ""),
-      moving: readIniString(ini, section, "def_state_moving", false, "", baseMoving),
+      standing: readIniString(ini, section, "def_state_standing", false),
+      moving: readIniString(ini, section, "def_state_moving", false, null, baseMoving),
     };
 
     state.path_walk_info = null;

--- a/src/engine/core/schemes/stalker/wounded/SchemeWounded.ts
+++ b/src/engine/core/schemes/stalker/wounded/SchemeWounded.ts
@@ -73,8 +73,8 @@ export class SchemeWounded extends AbstractScheme {
   ): void {
     const woundedSection: TSection =
       scheme === null || scheme === EScheme.NIL
-        ? readIniString(state.ini, state.sectionLogic, "wounded", false, "")
-        : readIniString(state.ini, section, "wounded", false, "");
+        ? readIniString(state.ini, state.sectionLogic, "wounded", false)
+        : readIniString(state.ini, section, "wounded", false);
 
     SchemeWounded.initialize(object, state.ini, woundedSection, state.wounded as ISchemeWoundedState, scheme);
 
@@ -165,20 +165,20 @@ export class SchemeWounded extends AbstractScheme {
       state.enable_talk = true;
       state.notForHelp = defaults.not_for_help;
     } else {
-      state.hp_state = SchemeWounded.parseData(readIniString(ini, section, "hp_state", false, "", defaults.hp_state));
+      state.hp_state = SchemeWounded.parseData(readIniString(ini, section, "hp_state", false, null, defaults.hp_state));
       state.hp_state_see = SchemeWounded.parseData(
-        readIniString(ini, section, "hp_state_see", false, "", defaults.hp_state_see)
+        readIniString(ini, section, "hp_state_see", false, null, defaults.hp_state_see)
       );
       state.psy_state = SchemeWounded.parseData(
-        readIniString(ini, section, "psy_state", false, "", defaults.psy_state)
+        readIniString(ini, section, "psy_state", false, null, defaults.psy_state)
       );
       state.hp_victim = SchemeWounded.parseData(
-        readIniString(ini, section, "hp_victim", false, "", defaults.hp_victim)
+        readIniString(ini, section, "hp_victim", false, null, defaults.hp_victim)
       );
-      state.hp_cover = SchemeWounded.parseData(readIniString(ini, section, "hp_cover", false, "", defaults.hp_cover));
-      state.hp_fight = SchemeWounded.parseData(readIniString(ini, section, "hp_fight", false, "", defaults.hp_fight));
-      state.help_dialog = readIniString(ini, section, "help_dialog", false, "", defaults.help_dialog);
-      state.help_start_dialog = readIniString(ini, section, "help_start_dialog", false, "", null);
+      state.hp_cover = SchemeWounded.parseData(readIniString(ini, section, "hp_cover", false, null, defaults.hp_cover));
+      state.hp_fight = SchemeWounded.parseData(readIniString(ini, section, "hp_fight", false, null, defaults.hp_fight));
+      state.help_dialog = readIniString(ini, section, "help_dialog", false, null, defaults.help_dialog);
+      state.help_start_dialog = readIniString(ini, section, "help_start_dialog", false, null, null);
       state.use_medkit = readIniBoolean(ini, section, "use_medkit", false, defaults.use_medkit);
       state.autoheal = readIniBoolean(ini, section, "autoheal", false, true);
       state.enable_talk = readIniBoolean(ini, section, "enable_talk", false, true);

--- a/src/engine/core/utils/ini/ini_config.ts
+++ b/src/engine/core/utils/ini/ini_config.ts
@@ -217,7 +217,7 @@ export function getConfigObjectAndZone(ini: IniFile, section: TSection, field: T
  */
 export function getObjectConfigOverrides(ini: IniFile, section: TSection, object: ClientObject): AnyObject {
   const overrides: AnyObject = {};
-  const heliHunter: Optional<string> = readIniString(ini, section, "heli_hunter", false, "");
+  const heliHunter: Optional<string> = readIniString(ini, section, "heli_hunter", false);
 
   if (heliHunter !== null) {
     overrides.heli_hunter = parseConditionsList(heliHunter);
@@ -256,14 +256,14 @@ export function getObjectConfigOverrides(ini: IniFile, section: TSection, object
   }
 
   if (ini.line_exist(section, "on_offline")) {
-    overrides.on_offline_condlist = parseConditionsList(readIniString(ini, section, "on_offline", false, "", NIL));
+    overrides.on_offline_condlist = parseConditionsList(readIniString(ini, section, "on_offline", false, null, NIL));
   } else {
     overrides.on_offline_condlist = parseConditionsList(
-      readIniString(ini, state.sectionLogic, "on_offline", false, "", NIL)
+      readIniString(ini, state.sectionLogic, "on_offline", false, null, NIL)
     );
   }
 
-  overrides.soundgroup = readIniString(ini, section, "soundgroup", false, "");
+  overrides.soundgroup = readIniString(ini, section, "soundgroup", false);
 
   return overrides;
 }

--- a/src/engine/core/utils/ini/ini_read.ts
+++ b/src/engine/core/utils/ini/ini_read.ts
@@ -25,22 +25,24 @@ export function readIniString<D = string>(
   prefix: Optional<string> = null,
   defaultValue: D = null as unknown as D
 ): D {
-  assertDefined(required, "Section '%s', wrong arguments order in call to 'readIniString'.", section);
+  if (required === null) {
+    abort("Section '%s', wrong arguments order in call to 'readIniString'.", section);
+  }
 
-  // todo: Resolve prefix.
   if (section && ini.section_exist(section) && ini.line_exist(section, field)) {
+    // todo: Resolve prefix. Probably should change order of default value and prefix.
     if (prefix && prefix !== "") {
-      return (prefix + "_" + ini.r_string(section, field)) as D;
+      return string.format("%s_%s", prefix, ini.r_string(section, field)) as D;
     } else {
       return ini.r_string(section, field) as D;
     }
   }
 
-  if (!required) {
-    return defaultValue as D;
+  if (required) {
+    return abort("Attempt to read a non-existent string field '%s' in section '%s'.", field, section);
   }
 
-  return abort("Attempt to read a non-existent string field '%s' in section '%s'.", field, section);
+  return defaultValue as D;
 }
 
 /**
@@ -143,7 +145,7 @@ export function readIniTwoNumbers(
  * @returns logics scheme object
  */
 export function readIniConditionList(ini: IniFile, section: TSection, field: TName): Optional<IBaseSchemeLogic> {
-  const data: Optional<string> = readIniString(ini, section, field, false, "");
+  const data: Optional<string> = readIniString(ini, section, field, false);
 
   if (!data) {
     return null;
@@ -172,7 +174,7 @@ export function readIniConditionList(ini: IniFile, section: TSection, field: TNa
  * @returns logics scheme object
  */
 export function readIniStringAndCondList(ini: IniFile, section: TSection, field: TName): Optional<IBaseSchemeLogic> {
-  const data: string = readIniString(ini, section, field, false, "");
+  const data: string = readIniString(ini, section, field, false);
 
   if (!data) {
     return null;
@@ -205,7 +207,7 @@ export function readIniNumberAndConditionList(
   section: TSection,
   field: TName
 ): Optional<IBaseSchemeLogic> {
-  const data: Optional<string> = readIniString(ini, section, field, false, "");
+  const data: Optional<string> = readIniString(ini, section, field, false);
 
   if (!data) {
     return null;
@@ -238,7 +240,7 @@ export function readIniTwoStringsAndConditionsList(
   section: TSection,
   field: TName
 ): Optional<IBaseSchemeLogic> {
-  const data: string = readIniString(ini, section, field, false, "");
+  const data: string = readIniString(ini, section, field, false);
 
   if (!data) {
     return null;

--- a/src/engine/core/utils/job/job_create/job_create_exclusive.ts
+++ b/src/engine/core/utils/job/job_create/job_create_exclusive.ts
@@ -72,7 +72,7 @@ export function createExclusiveJob(
 ): TSmartTerrainJobsList {
   logger.format("Add exclusive job: '%s' - '%s'", section, field);
 
-  const workScriptPath: Optional<TPath> = readIniString(ini, section, field, false, "", null);
+  const workScriptPath: Optional<TPath> = readIniString(ini, section, field, false);
 
   // Field with work path does not exist, nothing to load.
   if (workScriptPath === null) {
@@ -84,11 +84,11 @@ export function createExclusiveJob(
   assert(getFS().exist(roots.gameConfig, iniPath), "There is no job configuration file '%s'.", iniPath);
 
   const jobIniFile: Optional<IniFile> = new ini_file(iniPath);
-  const jobOnline: Optional<string> = readIniString(jobIniFile, "logic@" + field, "job_online", false, "", null);
+  const jobOnline: Optional<string> = readIniString(jobIniFile, "logic@" + field, "job_online", false);
   const jobPriority: TRate = readIniNumber(jobIniFile, "logic@" + field, "prior", false, 45);
-  const jobSuitableCondlist: Optional<string> = readIniString(jobIniFile, "logic@" + field, "suitable", false, "");
+  const jobSuitableCondlist: Optional<string> = readIniString(jobIniFile, "logic@" + field, "suitable", false);
   const isMonster: boolean = readIniBoolean(jobIniFile, "logic@" + field, "monster_job", false, false);
-  const activeSection: TSection = readIniString(jobIniFile, "logic@" + field, "active", false, "");
+  const activeSection: TSection = readIniString(jobIniFile, "logic@" + field, "active", false);
   const scheme: Optional<EScheme> = getSchemeFromSection(activeSection) as EScheme;
 
   let pathType: Optional<EJobPathType> = (JobPathTypeByScheme[scheme] as EJobPathType) || null;

--- a/src/engine/core/utils/scheme/scheme_initialization.ts
+++ b/src/engine/core/utils/scheme/scheme_initialization.ts
@@ -75,7 +75,7 @@ export function configureObjectSchemes(
 
   if (ini.section_exist(logicsSection)) {
     // Read target configuration object in a recursive way and then `configureObjectSchemes` with final ini file.
-    const filename: Optional<TName> = readIniString(ini, logicsSection, "cfg", false, "");
+    const filename: Optional<TName> = readIniString(ini, logicsSection, "cfg", false);
 
     // Read ini file if section `cfg` exists and load it.
     if (filename) {
@@ -135,7 +135,7 @@ export function configureObjectSchemes(
       logicsSection,
       "trade",
       false,
-      "",
+      null,
       logicsConfig.TRADE.DEFAULT_TRADE_LTX_PATH
     );
 
@@ -239,7 +239,7 @@ export function initializeObjectSchemeLogic(
 
     activateSchemeBySection(object, iniFile, section, state.smartTerrainName, false);
 
-    const relation: Optional<ERelation> = readIniString(iniFile, "logic", "relation", false, "") as ERelation;
+    const relation: Optional<ERelation> = readIniString(iniFile, "logic", "relation", false) as ERelation;
 
     switch (relation) {
       case ERelation.NEUTRAL:
@@ -269,7 +269,7 @@ export function initializeObjectSchemeLogic(
  * @param state - object registry state
  */
 export function initializeObjectSectionItems(object: ClientObject, state: IRegistryObjectState): void {
-  const spawnItemsSection: Optional<TSection> = readIniString(state.ini, state.sectionLogic, "spawn", false, "", null);
+  const spawnItemsSection: Optional<TSection> = readIniString(state.ini, state.sectionLogic, "spawn", false);
 
   if (spawnItemsSection === null) {
     return;

--- a/src/engine/core/utils/scheme/scheme_logic.ts
+++ b/src/engine/core/utils/scheme/scheme_logic.ts
@@ -187,25 +187,25 @@ export function enableObjectBaseSchemes(
       registry.schemes.get(EScheme.DANGER).activate(object, ini, EScheme.DANGER, "danger");
       registry.schemes.get(EScheme.GATHER_ITEMS).activate(object, ini, EScheme.GATHER_ITEMS, "gather_items");
 
-      const combatSection: TSection = readIniString(ini, logicsSection, "on_combat", false, "");
+      const combatSection: TSection = readIniString(ini, logicsSection, "on_combat", false);
 
       registry.schemes.get(EScheme.COMBAT).activate(object, ini, EScheme.COMBAT, combatSection);
 
       initializeObjectInvulnerability(object);
 
-      const infoSection: Optional<TSection> = readIniString(ini, logicsSection, "info", false, "");
+      const infoSection: Optional<TSection> = readIniString(ini, logicsSection, "info", false);
 
       if (infoSection !== null) {
         initializeObjectInfo(object, ini, infoSection);
       }
 
-      const hitSection: Optional<string> = readIniString(ini, logicsSection, "on_hit", false, "");
+      const hitSection: Optional<string> = readIniString(ini, logicsSection, "on_hit", false);
 
       if (hitSection !== null) {
         registry.schemes.get(EScheme.HIT).activate(object, ini, EScheme.HIT, hitSection);
       }
 
-      const woundedSection: TSection = readIniString(ini, logicsSection, "wounded", false, "");
+      const woundedSection: TSection = readIniString(ini, logicsSection, "wounded", false);
 
       // todo: null can be replaced with actual section.
       registry.schemes.get(EScheme.WOUNDED).activate(object, ini, EScheme.WOUNDED, woundedSection);
@@ -217,11 +217,11 @@ export function enableObjectBaseSchemes(
         .get(EScheme.CORPSE_DETECTION)
         .activate(object, ini, EScheme.CORPSE_DETECTION, null as unknown as TSection);
 
-      const meetSection: TSection = readIniString(ini, logicsSection, "meet", false, "");
+      const meetSection: TSection = readIniString(ini, logicsSection, "meet", false);
 
       registry.schemes.get(EScheme.MEET).activate(object, ini, EScheme.MEET, meetSection);
 
-      const deathSection: TSection = readIniString(ini, logicsSection, "on_death", false, "");
+      const deathSection: TSection = readIniString(ini, logicsSection, "on_death", false);
 
       registry.schemes.get(EScheme.DEATH).activate(object, ini, EScheme.DEATH, deathSection);
       // todo: null can be replaced with actual section.
@@ -235,13 +235,13 @@ export function enableObjectBaseSchemes(
     }
 
     case ESchemeType.MONSTER: {
-      const combatSection: Optional<TSection> = readIniString(ini, logicsSection, "on_combat", false, "");
+      const combatSection: Optional<TSection> = readIniString(ini, logicsSection, "on_combat", false);
 
       if (combatSection !== null) {
         registry.schemes.get(EScheme.MOB_COMBAT).activate(object, ini, EScheme.MOB_COMBAT, combatSection);
       }
 
-      const deathSection: Optional<TSection> = readIniString(ini, logicsSection, "on_death", false, "");
+      const deathSection: Optional<TSection> = readIniString(ini, logicsSection, "on_death", false);
 
       if (deathSection !== null) {
         registry.schemes.get(EScheme.MOB_DEATH).activate(object, ini, EScheme.MOB_DEATH, deathSection);
@@ -249,7 +249,7 @@ export function enableObjectBaseSchemes(
 
       initializeObjectInvulnerability(object);
 
-      const hitSection: Optional<TSection> = readIniString(ini, logicsSection, "on_hit", false, "");
+      const hitSection: Optional<TSection> = readIniString(ini, logicsSection, "on_hit", false);
 
       if (hitSection !== null) {
         registry.schemes.get(EScheme.HIT).activate(object, ini, EScheme.HIT, hitSection);
@@ -263,7 +263,7 @@ export function enableObjectBaseSchemes(
     }
 
     case ESchemeType.OBJECT: {
-      const hitSection: Optional<TSection> = readIniString(ini, logicsSection, "on_hit", false, "");
+      const hitSection: Optional<TSection> = readIniString(ini, logicsSection, "on_hit", false);
 
       if (hitSection !== null) {
         registry.schemes.get(EScheme.PH_ON_HIT).activate(object, ini, EScheme.PH_ON_HIT, hitSection);
@@ -273,7 +273,7 @@ export function enableObjectBaseSchemes(
     }
 
     case ESchemeType.HELICOPTER: {
-      const hitSection: Optional<TSection> = readIniString(ini, logicsSection, "on_hit", false, "");
+      const hitSection: Optional<TSection> = readIniString(ini, logicsSection, "on_hit", false);
 
       if (hitSection !== null) {
         registry.schemes.get(EScheme.HIT).activate(object, ini, EScheme.HIT, hitSection);

--- a/src/engine/core/utils/scheme/scheme_object_initialization.ts
+++ b/src/engine/core/utils/scheme/scheme_object_initialization.ts
@@ -18,14 +18,7 @@ import { ClientObject, EScheme, IniFile, LuaArray, Optional, TDistance, TNumberI
  */
 export function initializeObjectInvulnerability(object: ClientObject): void {
   const state: IRegistryObjectState = registry.objects.get(object.id());
-  const invulnerability: Optional<string> = readIniString(
-    state.ini,
-    state.activeSection,
-    "invulnerable",
-    false,
-    "",
-    null
-  );
+  const invulnerability: Optional<string> = readIniString(state.ini, state.activeSection, "invulnerable", false);
 
   const nextInvulnerabilityState: boolean =
     invulnerability === null
@@ -51,10 +44,10 @@ export function initializeObjectCanSelectWeaponState(
   state: IRegistryObjectState,
   section: TSection
 ): void {
-  let data: string = readIniString(state.ini, section, "can_select_weapon", false, "", "");
+  let data: string = readIniString(state.ini, section, "can_select_weapon", false, null, "");
 
   if (data === "") {
-    data = readIniString(state.ini, state.sectionLogic, "can_select_weapon", false, "", TRUE);
+    data = readIniString(state.ini, state.sectionLogic, "can_select_weapon", false, null, TRUE);
   }
 
   const canSelectSection: Optional<TSection> = pickSectionFromCondList(
@@ -116,11 +109,11 @@ export function initializeObjectGroup(object: ClientObject, ini: IniFile, sectio
 export function initializeObjectInfo(object: ClientObject, ini: IniFile, section: TSection): void {
   const inInfosList: LuaArray<TInfoPortion> = getSectionsFromConditionLists(
     object,
-    readIniString(ini, section, "in", false, "")
+    readIniString(ini, section, "in", false)
   );
   const outInfosList: LuaArray<TInfoPortion> = getSectionsFromConditionLists(
     object,
-    readIniString(ini, section, "out", false, "")
+    readIniString(ini, section, "out", false)
   );
 
   for (const [, infoPortion] of inInfosList) {
@@ -148,8 +141,8 @@ export function initializeObjectIgnoreThreshold(
 ): void {
   const thresholdSection: Optional<TSection> =
     scheme === null || scheme === NIL
-      ? readIniString(state.ini, state.sectionLogic, "threshold", false, "")
-      : readIniString(state.ini, section, "threshold", false, "");
+      ? readIniString(state.ini, state.sectionLogic, "threshold", false)
+      : readIniString(state.ini, section, "threshold", false);
 
   if (thresholdSection) {
     const maxIgnoreDistance: Optional<TDistance> = readIniNumber(

--- a/src/engine/core/utils/squad/squad_state.ts
+++ b/src/engine/core/utils/squad/squad_state.ts
@@ -23,7 +23,7 @@ export function updateSquadInvulnerabilityState(squad: Squad): void {
 
       if (
         object.invulnerable() !== invulnerability &&
-        readIniString(objectState.ini, objectState.activeSection, "invulnerable", false, "", null) === null
+        readIniString(objectState.ini, objectState.activeSection, "invulnerable", false) === null
       ) {
         object.invulnerable(invulnerability);
       }

--- a/src/engine/scripts/declarations/effects/object.ts
+++ b/src/engine/scripts/declarations/effects/object.ts
@@ -362,7 +362,7 @@ extern(
       let spawnPoint: TStringId;
 
       if (params[2] === "simulation_point") {
-        const data: string = readIniString(SYSTEM_INI, squad.section_name(), "spawn_point", false, "");
+        const data: string = readIniString(SYSTEM_INI, squad.section_name(), "spawn_point", false);
         const condlist: LuaArray<IConfigSwitchCondition> =
           data === "" || data === null
             ? parseConditionsList(squadSmartTerrain.spawnPointName as string)


### PR DESCRIPTION
## Changes

- Do not use prefix param for readIniString where not needed
- Use null over empty string where possible
- Shorter call signature for read ini string where possible 
- Simplify readIniString  method
- Rename additional to smartTerrainName where changes applied.
- Rename `gulag` to `smartTerrain` where changes applied.

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are included
- [ ] documentation is changed or added
