### PR TITLE
[FIXES] Fixing codestyle / mismatch between camelCase and snake_case props of overrides

### DIFF
--- a/.idea/runConfigurations/lint_strict.xml
+++ b/.idea/runConfigurations/lint_strict.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="lint:strict" type="js.build_tools.npm" folderName="dev" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="lint:strict" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/engine/core/database/database_types.ts
+++ b/src/engine/core/database/database_types.ts
@@ -132,15 +132,15 @@ export interface IRegistryObjectStateLogic {
  * State logics overrides descriptor.
  */
 export interface ILogicsOverrides {
-  heli_hunter: Optional<TConditionList>;
-  combat_ignore: Optional<IBaseSchemeLogic>;
-  combat_ignore_keep_when_attacked: Optional<boolean>;
+  heliHunter: Optional<TConditionList>;
+  combatIgnore: Optional<IBaseSchemeLogic>;
+  combatIgnoreKeepWhenAttacked: Optional<boolean>;
   combatType: Optional<IBaseSchemeLogic>;
   scriptCombatType: Optional<TName>;
-  on_combat: Optional<IBaseSchemeLogic>;
   minPostCombatTime: TDuration;
   maxPostCombatTime: TDuration;
-  on_offline_condlist: Optional<TConditionList>;
+  onCombat: Optional<IBaseSchemeLogic>;
+  onOffline: Optional<TConditionList>;
   soundgroup: Optional<TName>;
 }
 

--- a/src/engine/core/database/database_types.ts
+++ b/src/engine/core/database/database_types.ts
@@ -12,6 +12,7 @@ import {
   IniFile,
   LuaArray,
   Optional,
+  TDuration,
   Time,
   TName,
   TNumberId,
@@ -55,7 +56,7 @@ export interface IBaseSchemeState {
   scheme: EScheme;
   section: Optional<TSection>;
   actions?: LuaTable<AnyObject, boolean>;
-  overrides: Optional<AnyObject>;
+  overrides: Optional<ILogicsOverrides>;
 }
 
 /**
@@ -96,7 +97,7 @@ export interface IRegistryObjectStateLogic {
   /**
    * todo;
    */
-  overrides: Optional<AnyObject>;
+  overrides: Optional<ILogicsOverrides>;
   /**
    * Time of logics section activation - absolute.
    */
@@ -125,6 +126,22 @@ export interface IRegistryObjectStateLogic {
    * Describes last active smart terrain name when game was saved.
    */
   loadedSmartTerrainName: Optional<TName>;
+}
+
+/**
+ * State logics overrides descriptor.
+ */
+export interface ILogicsOverrides {
+  heli_hunter: Optional<TConditionList>;
+  combat_ignore: Optional<IBaseSchemeLogic>;
+  combat_ignore_keep_when_attacked: Optional<boolean>;
+  combatType: Optional<IBaseSchemeLogic>;
+  scriptCombatType: Optional<TName>;
+  on_combat: Optional<IBaseSchemeLogic>;
+  minPostCombatTime: TDuration;
+  maxPostCombatTime: TDuration;
+  on_offline_condlist: Optional<TConditionList>;
+  soundgroup: Optional<TName>;
 }
 
 /**
@@ -188,7 +205,7 @@ export interface IRegistryObjectState extends Record<EScheme, Optional<IBaseSche
   /**
    * todo;
    */
-  script_combat_type: Optional<TName>;
+  scriptCombatType: Optional<TName>;
   /**
    * Optional ID of linked camp game object, if registered object is in it.
    */

--- a/src/engine/core/managers/achievements/achievements_preconditions.test.ts
+++ b/src/engine/core/managers/achievements/achievements_preconditions.test.ts
@@ -28,7 +28,6 @@ import {
 } from "@/engine/core/managers/achievements/achievements_preconditions";
 import { achievementRewards } from "@/engine/core/managers/achievements/achievements_rewards";
 import { EAchievement } from "@/engine/core/managers/achievements/achievements_types";
-import { AchievementsManager } from "@/engine/core/managers/achievements/AchievementsManager";
 import { EGameEvent, EventsManager } from "@/engine/core/managers/events";
 import { ENotificationType, ITipNotification } from "@/engine/core/managers/notifications";
 import { StatisticsManager } from "@/engine/core/managers/statistics";

--- a/src/engine/core/managers/achievements/achievements_preconditions.ts
+++ b/src/engine/core/managers/achievements/achievements_preconditions.ts
@@ -10,7 +10,6 @@ import { increaseCommunityGoodwillToId } from "@/engine/core/utils/relation";
 import { communities } from "@/engine/lib/constants/communities";
 import { ACTOR_ID } from "@/engine/lib/constants/ids";
 import { infoPortions } from "@/engine/lib/constants/info_portions";
-import { TNumberId } from "@/engine/lib/types";
 
 /**
  * todo: Description.

--- a/src/engine/core/managers/debug/DebugManager.ts
+++ b/src/engine/core/managers/debug/DebugManager.ts
@@ -203,7 +203,7 @@ export class DebugManager extends AbstractManager {
     logger.info("State overrides:", toJSON(state.overrides));
     logger.info("Enemy id:", state.enemyId);
     logger.info("Enemy name:", state.enemyId ? registry.simulator.object(state.enemyId)?.name() : NIL);
-    logger.info("Script combat type:", state.script_combat_type);
+    logger.info("Script combat type:", String(state.scriptCombatType));
     logger.info("Registered camp:", state.camp || "none");
 
     logger.pushSeparator();

--- a/src/engine/core/managers/sounds/GlobalSoundManager.ts
+++ b/src/engine/core/managers/sounds/GlobalSoundManager.ts
@@ -1,4 +1,4 @@
-import { closeLoadMarker, closeSaveMarker, openLoadMarker, openSaveMarker, registry } from "@/engine/core/database";
+import { closeLoadMarker, closeSaveMarker, openLoadMarker, openSaveMarker } from "@/engine/core/database";
 import { AbstractManager } from "@/engine/core/managers/base/AbstractManager";
 import { EGameEvent, EventsManager } from "@/engine/core/managers/events";
 import { AbstractPlayableSound } from "@/engine/core/managers/sounds/objects/AbstractPlayableSound";

--- a/src/engine/core/objects/binders/creature/MonsterBinder.ts
+++ b/src/engine/core/objects/binders/creature/MonsterBinder.ts
@@ -153,8 +153,7 @@ export class MonsterBinder extends object_binder {
     }
 
     const state: IRegistryObjectState = registry.objects.get(this.object.id());
-    const onOfflineConditionsList: Optional<TConditionList> = state?.overrides
-      ?.on_offline_condlist as Optional<TConditionList>;
+    const onOfflineConditionsList: Optional<TConditionList> = state?.overrides?.onOffline as Optional<TConditionList>;
 
     if (onOfflineConditionsList !== null) {
       pickSectionFromCondList(registry.actor, this.object, onOfflineConditionsList);

--- a/src/engine/core/objects/binders/creature/MonsterBinder.ts
+++ b/src/engine/core/objects/binders/creature/MonsterBinder.ts
@@ -153,11 +153,11 @@ export class MonsterBinder extends object_binder {
     }
 
     const state: IRegistryObjectState = registry.objects.get(this.object.id());
-    const onOfflineConditionsList: Optional<TConditionList> =
-      state !== null && state.overrides && state.overrides.on_offline_condlist;
+    const onOfflineConditionsList: Optional<TConditionList> = state?.overrides
+      ?.on_offline_condlist as Optional<TConditionList>;
 
     if (onOfflineConditionsList !== null) {
-      pickSectionFromCondList(registry.actor, this.object, onOfflineConditionsList as any);
+      pickSectionFromCondList(registry.actor, this.object, onOfflineConditionsList);
     }
 
     if (!this.object.alive()) {

--- a/src/engine/core/objects/binders/creature/StalkerBinder.ts
+++ b/src/engine/core/objects/binders/creature/StalkerBinder.ts
@@ -59,9 +59,8 @@ import { misc } from "@/engine/lib/constants/items/misc";
 import { MAX_U16 } from "@/engine/lib/constants/memory";
 import {
   ActionPlanner,
-  AnyObject,
-  EGameObjectRelation,
   EScheme,
+  EGameObjectRelation,
   ESchemeEvent,
   GameObject,
   NetPacket,
@@ -217,8 +216,7 @@ export class StalkerBinder extends object_binder {
     }
 
     // Call logics on offline.
-    const onOfflineConditionList: Optional<TConditionList> = state.overrides
-      ?.on_offline_condlist as Optional<TConditionList>;
+    const onOfflineConditionList: Optional<TConditionList> = state.overrides?.onOffline as Optional<TConditionList>;
 
     if (onOfflineConditionList !== null) {
       pickSectionFromCondList(registry.actor, this.object, onOfflineConditionList);
@@ -569,10 +567,10 @@ export class StalkerBinder extends object_binder {
     }
 
     // Probably should be reversed?
-    if (this.state.combat_ignore) {
+    if (this.state[EScheme.COMBAT_IGNORE]) {
       emitSchemeEvent(
         this.object,
-        this.state.combat_ignore,
+        this.state[EScheme.COMBAT_IGNORE],
         ESchemeEvent.HIT,
         object,
         amount,
@@ -582,12 +580,30 @@ export class StalkerBinder extends object_binder {
       );
     }
 
-    if (this.state.combat) {
-      emitSchemeEvent(this.object, this.state.combat, ESchemeEvent.HIT, object, amount, direction, who, boneIndex);
+    if (this.state[EScheme.COMBAT]) {
+      emitSchemeEvent(
+        this.object,
+        this.state[EScheme.COMBAT],
+        ESchemeEvent.HIT,
+        object,
+        amount,
+        direction,
+        who,
+        boneIndex
+      );
     }
 
-    if (this.state.hit) {
-      emitSchemeEvent(this.object, this.state.hit, ESchemeEvent.HIT, object, amount, direction, who, boneIndex);
+    if (this.state[EScheme.HIT]) {
+      emitSchemeEvent(
+        this.object,
+        this.state[EScheme.HIT],
+        ESchemeEvent.HIT,
+        object,
+        amount,
+        direction,
+        who,
+        boneIndex
+      );
     }
 
     if (boneIndex !== 15 && amount > this.object.health * 100) {
@@ -621,8 +637,8 @@ export function updateStalkerLogic(object: GameObject): void {
       const overrides: Optional<ILogicsOverrides> = state.overrides;
 
       if (overrides !== null) {
-        if (overrides.on_combat) {
-          pickSectionFromCondList(actor, object, overrides.on_combat.condlist);
+        if (overrides.onCombat) {
+          pickSectionFromCondList(actor, object, overrides.onCombat.condlist);
         }
 
         if (combatState?.logic) {

--- a/src/engine/core/objects/binders/creature/StalkerBinder.ts
+++ b/src/engine/core/objects/binders/creature/StalkerBinder.ts
@@ -59,8 +59,8 @@ import { misc } from "@/engine/lib/constants/items/misc";
 import { MAX_U16 } from "@/engine/lib/constants/memory";
 import {
   ActionPlanner,
-  EScheme,
   EGameObjectRelation,
+  EScheme,
   ESchemeEvent,
   GameObject,
   NetPacket,

--- a/src/engine/core/objects/binders/physic/PhysicObjectBinder.test.ts
+++ b/src/engine/core/objects/binders/physic/PhysicObjectBinder.test.ts
@@ -1,11 +1,175 @@
-import { describe, it } from "@jest/globals";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { level, particles_object } from "xray16";
+
+import { ILogicsOverrides, IRegistryObjectState, registerObject, registry } from "@/engine/core/database";
+import { GlobalSoundManager } from "@/engine/core/managers/sounds";
+import { PhysicObjectItemBox } from "@/engine/core/objects/binders";
+import { PhysicObjectBinder } from "@/engine/core/objects/binders/physic/PhysicObjectBinder";
+import { hasInfoPortion } from "@/engine/core/utils/info_portion";
+import { parseConditionsList } from "@/engine/core/utils/ini";
+import { emitSchemeEvent } from "@/engine/core/utils/scheme";
+import { EScheme, ESchemeEvent } from "@/engine/lib/types";
+import { mockRegisteredActor, mockSchemeState, resetRegistry } from "@/fixtures/engine";
+import {
+  EPacketDataType,
+  mockGameObject,
+  mockIniFile,
+  mockNetPacket,
+  MockNetProcessor,
+  mockNetReader,
+  mockServerAlifeObject,
+} from "@/fixtures/xray";
+
+jest.mock("@/engine/core/utils/scheme/scheme_event", () => ({
+  emitSchemeEvent: jest.fn(),
+}));
 
 describe("PhysicObjectBinder class", () => {
-  it.todo("should correctly initialize");
+  beforeEach(() => {
+    resetRegistry();
+    mockRegisteredActor();
+  });
 
-  it.todo("should correctly handle going online/offline");
+  it("should correctly handle going online/offline with defaults", () => {
+    const binder: PhysicObjectBinder = new PhysicObjectBinder(mockGameObject());
+    const soundManager: GlobalSoundManager = GlobalSoundManager.getInstance();
+
+    jest.spyOn(soundManager, "stopSoundByObjectId").mockImplementation(jest.fn());
+
+    binder.net_spawn(mockServerAlifeObject({ id: binder.object.id() }));
+
+    const state: IRegistryObjectState = registry.objects.get(binder.object.id());
+
+    expect(state).not.toBeNull();
+    expect(binder.itemBox).toBeNull();
+
+    binder.reinit();
+
+    expect(registry.objects.get(binder.object.id())).not.toBe(state);
+    expect(registry.objects.get(binder.object.id())).toEqual(state);
+
+    binder.net_destroy();
+
+    expect(registry.objects.has(binder.object.id())).toBe(false);
+    expect(soundManager.stopSoundByObjectId).toHaveBeenCalledWith(binder.object.id());
+  });
+
+  it("should correctly handle with extended config", () => {
+    const binder: PhysicObjectBinder = new PhysicObjectBinder(mockGameObject());
+    const soundManager: GlobalSoundManager = GlobalSoundManager.getInstance();
+
+    jest.spyOn(soundManager, "stopSoundByObjectId").mockImplementation(jest.fn());
+    jest.spyOn(binder.object, "spawn_ini").mockImplementation(() => {
+      return mockIniFile("test.ltx", {
+        drop_box: {
+          a: 1,
+        },
+        level_spot: {
+          actor_box: true,
+        },
+      });
+    });
+
+    binder.net_spawn(mockServerAlifeObject({ id: binder.object.id() }));
+
+    const state: IRegistryObjectState = registry.objects.get(binder.object.id());
+
+    expect(binder.itemBox).toBeInstanceOf(PhysicObjectItemBox);
+    expect(level.map_add_object_spot).toHaveBeenCalledWith(
+      binder.object.id(),
+      "ui_pda2_actor_box_location",
+      "st_ui_pda_actor_box"
+    );
+
+    jest.spyOn(level, "map_has_object_spot").mockImplementationOnce(() => 1);
+
+    state.activeScheme = EScheme.ANIMPOINT;
+    state.overrides = { onOffline: parseConditionsList("%+test_info_pb% test") } as ILogicsOverrides;
+    binder.particle = { stop: jest.fn() } as unknown as particles_object;
+    state[EScheme.ANIMPOINT] = mockSchemeState(EScheme.ANIMPOINT);
+
+    binder.net_destroy();
+
+    expect(registry.objects.has(binder.object.id())).toBe(false);
+    expect(soundManager.stopSoundByObjectId).toHaveBeenCalledWith(binder.object.id());
+    expect(level.map_remove_object_spot).toHaveBeenCalledWith(binder.object.id(), "ui_pda2_actor_box_location");
+    expect(binder.particle.stop).toHaveBeenCalled();
+
+    expect(emitSchemeEvent).toHaveBeenCalledWith(
+      binder.object,
+      state[EScheme.ANIMPOINT],
+      ESchemeEvent.SWITCH_OFFLINE,
+      binder.object
+    );
+    expect(hasInfoPortion("test_info_pb")).toBe(true);
+  });
 
   it.todo("should correctly handle update events");
+
+  it("should be save relevant", () => {
+    const binder: PhysicObjectBinder = new PhysicObjectBinder(mockGameObject());
+
+    expect(binder.net_save_relevant()).toBe(true);
+  });
+
+  it("should correctly handle save/load", () => {
+    jest.spyOn(Date, "now").mockImplementation(() => 5000);
+
+    const netProcessor: MockNetProcessor = new MockNetProcessor();
+    const binder: PhysicObjectBinder = new PhysicObjectBinder(mockGameObject());
+    const binderState: IRegistryObjectState = registerObject(binder.object);
+
+    binderState.jobIni = "test.ltx";
+    binderState.iniFilename = "test_filename.ltx";
+    binderState.sectionLogic = "logic";
+    binderState.activeSection = "test@test";
+    binderState.smartTerrainName = "test-smart";
+
+    binder.save(mockNetPacket(netProcessor));
+
+    expect(netProcessor.writeDataOrder).toEqual([
+      EPacketDataType.STRING,
+      EPacketDataType.STRING,
+      EPacketDataType.STRING,
+      EPacketDataType.STRING,
+      EPacketDataType.STRING,
+      EPacketDataType.STRING,
+      EPacketDataType.I32,
+      EPacketDataType.U8,
+      EPacketDataType.U32,
+      EPacketDataType.U16,
+      EPacketDataType.U16,
+    ]);
+    expect(netProcessor.dataList).toEqual([
+      "save_from_PhysicObjectBinder",
+      "test.ltx",
+      "test_filename.ltx",
+      "logic",
+      "test@test",
+      "test-smart",
+      -5000,
+      255,
+      0,
+      8,
+      10,
+    ]);
+
+    const newBinder: PhysicObjectBinder = new PhysicObjectBinder(mockGameObject());
+    const newBinderState: IRegistryObjectState = registerObject(newBinder.object);
+
+    newBinder.load(mockNetReader(netProcessor));
+
+    expect(newBinder.isLoaded).toBe(true);
+    expect(newBinder.isInitialized).toBe(false);
+    expect(newBinderState.jobIni).toBe("test.ltx");
+    expect(newBinderState.loadedSectionLogic).toBe("logic");
+    expect(newBinderState.loadedActiveSection).toBe("test@test");
+    expect(newBinderState.loadedSmartTerrainName).toBe("test-smart");
+    expect(newBinderState.loadedIniFilename).toBe("test_filename.ltx");
+
+    expect(netProcessor.readDataOrder).toEqual(netProcessor.writeDataOrder);
+    expect(netProcessor.dataList).toHaveLength(0);
+  });
 
   it.todo("should correctly handle hit events");
 

--- a/src/engine/core/objects/binders/physic/PhysicObjectBinder.ts
+++ b/src/engine/core/objects/binders/physic/PhysicObjectBinder.ts
@@ -67,10 +67,11 @@ export class PhysicObjectBinder extends object_binder {
       emitSchemeEvent(this.object, state[state.activeScheme]!, ESchemeEvent.SWITCH_OFFLINE, this.object);
     }
 
-    const on_offline_condlist: Optional<TConditionList> = state?.overrides?.on_offline_condlist;
+    const onOfflineCondlist: Optional<TConditionList> = state?.overrides
+      ?.on_offline_condlist as Optional<TConditionList>;
 
-    if (on_offline_condlist !== null) {
-      pickSectionFromCondList(registry.actor, this.object, on_offline_condlist);
+    if (onOfflineCondlist !== null) {
+      pickSectionFromCondList(registry.actor, this.object, onOfflineCondlist);
     }
 
     if (this.particle !== null) {

--- a/src/engine/core/objects/binders/physic/PhysicObjectBinder.ts
+++ b/src/engine/core/objects/binders/physic/PhysicObjectBinder.ts
@@ -67,8 +67,7 @@ export class PhysicObjectBinder extends object_binder {
       emitSchemeEvent(this.object, state[state.activeScheme]!, ESchemeEvent.SWITCH_OFFLINE, this.object);
     }
 
-    const onOfflineCondlist: Optional<TConditionList> = state?.overrides
-      ?.on_offline_condlist as Optional<TConditionList>;
+    const onOfflineCondlist: Optional<TConditionList> = state?.overrides?.onOffline as Optional<TConditionList>;
 
     if (onOfflineCondlist !== null) {
       pickSectionFromCondList(registry.actor, this.object, onOfflineCondlist);

--- a/src/engine/core/objects/binders/physic/PhysicObjectBinder.ts
+++ b/src/engine/core/objects/binders/physic/PhysicObjectBinder.ts
@@ -59,7 +59,7 @@ export class PhysicObjectBinder extends object_binder {
       return false;
     }
 
-    const spawnIni: Optional<IniFile> = this.object.spawn_ini();
+    const spawnIni: Optional<IniFile> = this.object.spawn_ini() as Optional<IniFile>;
 
     if (spawnIni) {
       if (spawnIni.section_exist("drop_box")) {

--- a/src/engine/core/schemes/restrictor/sr_crow_spawner/CrowSpawnerManager.ts
+++ b/src/engine/core/schemes/restrictor/sr_crow_spawner/CrowSpawnerManager.ts
@@ -7,7 +7,7 @@ import { ISchemeCrowSpawnerState } from "@/engine/core/schemes/restrictor/sr_cro
 import { LuaLogger } from "@/engine/core/utils/logging";
 import { trySwitchToAnotherSection } from "@/engine/core/utils/scheme/scheme_switch";
 import { copyTable } from "@/engine/core/utils/table";
-import { AlifeSimulator, LuaArray, Patrol, TDuration, TIndex, TName, TTimestamp, Vector } from "@/engine/lib/types";
+import { AlifeSimulator, LuaArray, Patrol, TIndex, TName, TTimestamp, Vector } from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename);
 

--- a/src/engine/core/schemes/stalker/camper/utils/camper_utils.ts
+++ b/src/engine/core/schemes/stalker/camper/utils/camper_utils.ts
@@ -1,13 +1,8 @@
-import { danger_object, patrol, stalker_ids, time_global } from "xray16";
+import { patrol } from "xray16";
 
-import { setStalkerState } from "@/engine/core/database";
-import { EStalkerState, ILookTargetDescriptor } from "@/engine/core/objects/animation/types";
 import { ICampPoint, ISchemeCamperState } from "@/engine/core/schemes/stalker/camper/camper_types";
-import { isObjectFacingDanger } from "@/engine/core/schemes/stalker/danger/utils";
-import { abort } from "@/engine/core/utils/assertion";
-import { isObjectAtTerminalWaypoint, isObjectAtWaypoint } from "@/engine/core/utils/patrol";
-import { createVector } from "@/engine/core/utils/vector";
-import { DangerObject, GameObject, Optional, Patrol, TDangerType } from "@/engine/lib/types";
+import { isObjectAtWaypoint } from "@/engine/core/utils/patrol";
+import { GameObject, Optional, Patrol } from "@/engine/lib/types";
 
 /**
  * todo;

--- a/src/engine/core/schemes/stalker/combat/SchemeCombat.ts
+++ b/src/engine/core/schemes/stalker/combat/SchemeCombat.ts
@@ -49,12 +49,8 @@ export class SchemeCombat extends AbstractScheme {
       state.enabled = true;
       state.combatType = readIniConditionList(ini, section, "combat_type");
 
-      if ((state.combatType as unknown as string) === communities.monolith) {
-        state.combatType = null;
-      }
-
       if (!state.combatType && isZombied) {
-        state.combatType = { condlist: parseConditionsList(communities.zombied) };
+        state.combatType = { condlist: parseConditionsList(EScriptCombatType.ZOMBIED) };
       }
 
       if (state.combatType) {

--- a/src/engine/core/schemes/stalker/combat/combat_types.ts
+++ b/src/engine/core/schemes/stalker/combat/combat_types.ts
@@ -1,11 +1,14 @@
 import { IBaseSchemeState } from "@/engine/core/database/database_types";
-import { AnyObject, Optional, Vector } from "@/engine/lib/types";
+import { TConditionList } from "@/engine/core/utils/ini";
+import { Optional, Vector } from "@/engine/lib/types";
 
 /**
  * todo;
  */
 export enum EScriptCombatType {
   CAMPER = "camper",
+  ZOMBIED = "zombied",
+  MONOLITH = "monolith",
 }
 
 /**
@@ -21,7 +24,7 @@ export enum EZombieCombatAction {
  */
 export interface ISchemeCombatState extends IBaseSchemeState {
   enabled: boolean;
-  combatType: Optional<AnyObject>;
+  combatType: Optional<{ condlist: TConditionList }>;
   isCamperCombatAction: Optional<boolean>;
   lastSeenEnemyAtPosition: Optional<Vector>;
   scriptCombatType: Optional<EScriptCombatType>;

--- a/src/engine/core/schemes/stalker/combat/combat_types.ts
+++ b/src/engine/core/schemes/stalker/combat/combat_types.ts
@@ -3,7 +3,8 @@ import { TConditionList } from "@/engine/core/utils/ini";
 import { Optional, Vector } from "@/engine/lib/types";
 
 /**
- * todo;
+ * Type of combat used by game object.
+ * Each type overrides default behaviour and forces specific logics.
  */
 export enum EScriptCombatType {
   CAMPER = "camper",
@@ -12,7 +13,8 @@ export enum EScriptCombatType {
 }
 
 /**
- * todo;
+ * Current action type for zombie combat.
+ * Since zombies can do only few things, it includes related definitions.
  */
 export enum EZombieCombatAction {
   SHOOT = 1,
@@ -20,7 +22,8 @@ export enum EZombieCombatAction {
 }
 
 /**
- * todo;
+ * State of combat scheme.
+ * Configuration and parameters of current combat behaviour.
  */
 export interface ISchemeCombatState extends IBaseSchemeState {
   enabled: boolean;

--- a/src/engine/core/schemes/stalker/combat_camper/evaluator/EvaluatorCombatCamper.ts
+++ b/src/engine/core/schemes/stalker/combat_camper/evaluator/EvaluatorCombatCamper.ts
@@ -23,6 +23,6 @@ export class EvaluatorCombatCamper extends property_evaluator {
    */
   public override evaluate(): boolean {
     // todo: Probably get from this.state? Maybe invalid.
-    return registry.objects.get(this.object.id()).script_combat_type === EScriptCombatType.CAMPER;
+    return registry.objects.get(this.object.id()).scriptCombatType === EScriptCombatType.CAMPER;
   }
 }

--- a/src/engine/core/schemes/stalker/combat_idle/evaluators/EvaluatorHasEnemy.ts
+++ b/src/engine/core/schemes/stalker/combat_idle/evaluators/EvaluatorHasEnemy.ts
@@ -1,12 +1,12 @@
 import { LuabindClass, property_evaluator, time_global } from "xray16";
 
-import { registry } from "@/engine/core/database";
+import { ILogicsOverrides, registry } from "@/engine/core/database";
 import { combatConfig } from "@/engine/core/schemes/stalker/combat/CombatConfig";
 import { ISchemePostCombatIdleState } from "@/engine/core/schemes/stalker/combat_idle/combat_idle_types";
 import { canObjectSelectAsEnemy } from "@/engine/core/schemes/stalker/danger/utils";
 import { LuaLogger } from "@/engine/core/utils/logging";
 import { ACTOR_ID } from "@/engine/lib/constants/ids";
-import { GameObject, Optional, TDistance, TTimestamp } from "@/engine/lib/types";
+import { GameObject, Optional, TDistance, TDuration, TTimestamp } from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename);
 
@@ -48,9 +48,9 @@ export class EvaluatorHasEnemy extends property_evaluator {
     const now: TTimestamp = time_global();
 
     if (bestEnemy === null && this.state.timer === null) {
-      const overrides = registry.objects.get(this.object.id()).overrides;
-      const min: TDistance = overrides?.minPostCombatTime * 1000 || combatConfig.POST_COMBAT_IDLE.MIN;
-      const max: TDistance = overrides?.maxPostCombatTime * 1000 || combatConfig.POST_COMBAT_IDLE.MAX;
+      const overrides: Optional<ILogicsOverrides> = registry.objects.get(this.object.id()).overrides;
+      const min: TDistance = (overrides?.minPostCombatTime as TDuration) * 1000 || combatConfig.POST_COMBAT_IDLE.MIN;
+      const max: TDistance = (overrides?.maxPostCombatTime as TDuration) * 1000 || combatConfig.POST_COMBAT_IDLE.MAX;
 
       if (this.state.lastBestEnemyId === ACTOR_ID) {
         this.state.timer = now;

--- a/src/engine/core/schemes/stalker/combat_ignore/CombatProcessEnemyManager.ts
+++ b/src/engine/core/schemes/stalker/combat_ignore/CombatProcessEnemyManager.ts
@@ -8,7 +8,7 @@ import { LuaLogger } from "@/engine/core/utils/logging";
 import { startSmartTerrainAlarm } from "@/engine/core/utils/smart_terrain";
 import { ACTOR_ID } from "@/engine/lib/constants/ids";
 import { MAX_U16 } from "@/engine/lib/constants/memory";
-import { AnyObject, GameObject, Optional, ServerCreatureObject, TCount, TNumberId, Vector } from "@/engine/lib/types";
+import { GameObject, Optional, ServerCreatureObject, TCount, TNumberId, Vector } from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename);
 

--- a/src/engine/core/schemes/stalker/combat_ignore/CombatProcessEnemyManager.ts
+++ b/src/engine/core/schemes/stalker/combat_ignore/CombatProcessEnemyManager.ts
@@ -1,4 +1,4 @@
-import { registry } from "@/engine/core/database";
+import { ILogicsOverrides, registry } from "@/engine/core/database";
 import { AbstractSchemeManager } from "@/engine/core/objects/ai/scheme";
 import { SmartTerrain } from "@/engine/core/objects/server/smart_terrain/SmartTerrain";
 import { combatConfig } from "@/engine/core/schemes/stalker/combat/CombatConfig";
@@ -70,9 +70,9 @@ export class CombatProcessEnemyManager extends AbstractSchemeManager<ISchemeComb
     }
 
     if (who.id() === ACTOR_ID) {
-      const overrides: Optional<AnyObject> = this.state.overrides;
+      const overrides: Optional<ILogicsOverrides> = this.state.overrides;
 
-      if (!overrides || !overrides.combat_ignore_keep_when_attacked) {
+      if (!overrides || !overrides.combatIgnoreKeepWhenAttacked) {
         this.state.enabled = false;
       }
     }

--- a/src/engine/core/schemes/stalker/combat_zombied/SchemeCombatZombied.ts
+++ b/src/engine/core/schemes/stalker/combat_zombied/SchemeCombatZombied.ts
@@ -5,7 +5,7 @@ import { EActionId, EEvaluatorId } from "@/engine/core/objects/ai/types";
 import { ISchemeCombatState } from "@/engine/core/schemes/stalker/combat";
 import { ActionZombieGoToDanger, ActionZombieShoot } from "@/engine/core/schemes/stalker/combat_zombied/actions";
 import { EvaluatorCombatZombied } from "@/engine/core/schemes/stalker/combat_zombied/evaluators";
-import { assertDefined } from "@/engine/core/utils/assertion";
+import { assert } from "@/engine/core/utils/assertion";
 import { LuaLogger } from "@/engine/core/utils/logging";
 import { ActionPlanner, GameObject, IniFile } from "@/engine/lib/types";
 import { EScheme, ESchemeType, TSection } from "@/engine/lib/types/scheme";
@@ -14,15 +14,11 @@ const logger: LuaLogger = new LuaLogger($filename);
 
 /**
  * todo;
- * Note: not atomic scheme, just helper
  */
 export class SchemeCombatZombied extends AbstractScheme {
   public static override readonly SCHEME_SECTION: EScheme = EScheme.COMBAT_ZOMBIED;
   public static override readonly SCHEME_TYPE: ESchemeType = ESchemeType.STALKER;
 
-  /**
-   * todo: Description.
-   */
   public static override add(
     object: GameObject,
     ini: IniFile,
@@ -31,7 +27,9 @@ export class SchemeCombatZombied extends AbstractScheme {
     state: ISchemeCombatState,
     planner?: ActionPlanner
   ): void {
-    assertDefined(planner, "Expected planner to be provided for add method call.");
+    logger.info("Add zombied combat:", object.name());
+
+    assert(planner, "Expected planner to be provided for add method call.");
 
     planner.add_evaluator(EEvaluatorId.IS_COMBAT_ZOMBIED_ENABLED, new EvaluatorCombatZombied(state));
 
@@ -42,9 +40,10 @@ export class SchemeCombatZombied extends AbstractScheme {
     actionZombieShoot.add_precondition(new world_property(EEvaluatorId.IS_SCRIPTED_COMBAT, true));
     actionZombieShoot.add_effect(new world_property(EEvaluatorId.ENEMY, false));
     actionZombieShoot.add_effect(new world_property(EEvaluatorId.IS_STATE_LOGIC_ACTIVE, false));
+
     planner.add_action(EActionId.ZOMBIED_SHOOT, actionZombieShoot);
 
-    SchemeCombatZombied.subscribe(object, state, actionZombieShoot);
+    AbstractScheme.subscribe(object, state, actionZombieShoot);
 
     const actionZombieGoToDanger: ActionZombieGoToDanger = new ActionZombieGoToDanger(state);
 
@@ -54,8 +53,9 @@ export class SchemeCombatZombied extends AbstractScheme {
     actionZombieGoToDanger.add_precondition(new world_property(EEvaluatorId.DANGER, true));
     actionZombieGoToDanger.add_effect(new world_property(EEvaluatorId.DANGER, false));
     actionZombieGoToDanger.add_effect(new world_property(EEvaluatorId.IS_STATE_LOGIC_ACTIVE, false));
+
     planner.add_action(EActionId.ZOMBIED_GO_TO_DANGER, actionZombieGoToDanger);
 
-    SchemeCombatZombied.subscribe(object, state, actionZombieGoToDanger);
+    AbstractScheme.subscribe(object, state, actionZombieGoToDanger);
   }
 }

--- a/src/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieGoToDanger.test.ts
+++ b/src/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieGoToDanger.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { move, property_storage } from "xray16";
+
+import { EStalkerState } from "@/engine/core/objects/animation/types";
+import { EZombieCombatAction, ISchemeCombatState } from "@/engine/core/schemes/stalker/combat";
+import { ActionZombieGoToDanger } from "@/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieGoToDanger";
+import { EGameObjectPath, EScheme, GameObject } from "@/engine/lib/types";
+import { mockSchemeState, resetRegistry } from "@/fixtures/engine";
+import { mockGameObject } from "@/fixtures/xray";
+
+describe("ActionZombieGoToDanger", () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+
+  it("should correctly initialize", () => {
+    const enemy: GameObject = mockGameObject();
+    const object: GameObject = mockGameObject({ best_enemy: () => enemy });
+    const state: ISchemeCombatState = mockSchemeState(EScheme.COMBAT);
+    const action: ActionZombieGoToDanger = new ActionZombieGoToDanger(state);
+
+    action.setup(object, new property_storage());
+
+    expect(action.state).toBe(state);
+
+    state.currentAction = EZombieCombatAction.SHOOT;
+    action.lastState = EStalkerState.FIRE;
+    action.bestDangerObjectId = 1;
+    action.bestDangerObjectVertexId = 2;
+    action.lastSentVertexId = 3;
+
+    action.initialize();
+
+    expect(object.set_desired_direction).toHaveBeenCalled();
+    expect(object.set_detail_path_type).toHaveBeenCalledWith(move.line);
+    expect(object.set_path_type).toHaveBeenCalledWith(EGameObjectPath.LEVEL_PATH);
+
+    expect(state.currentAction).toBe(EZombieCombatAction.DANGER);
+    expect(action.lastState).toBeNull();
+    expect(action.bestDangerObjectId).toBeNull();
+    expect(action.bestDangerObjectVertexId).toBeNull();
+    expect(action.lastSentVertexId).toBeNull();
+  });
+
+  it("should correctly finalize", () => {
+    const enemy: GameObject = mockGameObject();
+    const object: GameObject = mockGameObject({ best_enemy: () => enemy });
+    const state: ISchemeCombatState = mockSchemeState(EScheme.COMBAT);
+    const action: ActionZombieGoToDanger = new ActionZombieGoToDanger(state);
+
+    action.setup(object, new property_storage());
+    action.initialize();
+    action.finalize();
+
+    expect(state.currentAction).toBeNull();
+  });
+
+  it.todo("should correctly execute");
+
+  it.todo("should correctly set states");
+
+  it.todo("should correctly handle hit");
+});

--- a/src/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieGoToDanger.ts
+++ b/src/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieGoToDanger.ts
@@ -54,6 +54,7 @@ export class ActionZombieGoToDanger extends action_base {
     this.object.set_desired_direction();
     this.object.set_detail_path_type(move.line);
     this.object.set_path_type(EGameObjectPath.LEVEL_PATH);
+
     this.lastState = null;
     this.bestDangerObjectId = null;
     this.bestDangerObjectVertexId = null;

--- a/src/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieGoToDanger.ts
+++ b/src/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieGoToDanger.ts
@@ -47,7 +47,7 @@ export class ActionZombieGoToDanger extends action_base {
    * todo: Description.
    */
   public override initialize(): void {
-    logger.info("Go to danger:", this.object.name());
+    logger.info("Activate:", this.object.name());
 
     super.initialize();
 
@@ -59,6 +59,16 @@ export class ActionZombieGoToDanger extends action_base {
     this.bestDangerObjectVertexId = null;
     this.lastSentVertexId = null;
     this.state.currentAction = EZombieCombatAction.DANGER;
+  }
+
+  /**
+   * todo: Description.
+   */
+  public override finalize(): void {
+    logger.info("Deactivate:", this.object.name());
+
+    super.finalize();
+    this.state.currentAction = null;
   }
 
   /**
@@ -107,16 +117,6 @@ export class ActionZombieGoToDanger extends action_base {
         this.setState(EStalkerState.THREAT_NA, null, bestDanger.position());
       }
     }
-  }
-
-  /**
-   * todo: Description.
-   */
-  public override finalize(): void {
-    logger.info("Stop going to danger:", this.object.name());
-
-    super.finalize();
-    this.state.currentAction = null;
   }
 
   /**

--- a/src/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieShoot.test.ts
+++ b/src/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieShoot.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { move, property_storage } from "xray16";
+
+import { setStalkerState } from "@/engine/core/database";
+import { GlobalSoundManager } from "@/engine/core/managers/sounds";
+import { EStalkerState } from "@/engine/core/objects/animation/types";
+import { EZombieCombatAction, ISchemeCombatState } from "@/engine/core/schemes/stalker/combat";
+import { ActionZombieShoot } from "@/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieShoot";
+import { MX_VECTOR, ONE_VECTOR, ZERO_VECTOR } from "@/engine/lib/constants/vectors";
+import { EScheme, GameObject, Vector } from "@/engine/lib/types";
+import { mockSchemeState, resetRegistry } from "@/fixtures/engine";
+import { mockGameObject } from "@/fixtures/xray";
+
+jest.mock("@/engine/core/database/stalker", () => ({
+  setStalkerState: jest.fn(),
+}));
+
+describe("ActionZombieShoot", () => {
+  beforeEach(() => {
+    resetRegistry();
+
+    GlobalSoundManager.getInstance().playSound = jest.fn(() => null);
+  });
+
+  it("should correctly initialize", () => {
+    const enemy: GameObject = mockGameObject();
+    const object: GameObject = mockGameObject({ best_enemy: () => enemy });
+    const state: ISchemeCombatState = mockSchemeState(EScheme.COMBAT);
+    const action: ActionZombieShoot = new ActionZombieShoot(state);
+
+    action.setup(object, new property_storage());
+
+    expect(action.state).toBe(state);
+
+    action.previousState = EStalkerState.FIRE;
+    action.enemyLastVertexId = 123;
+    action.isValidPath = true;
+    action.turnTime = 125;
+    state.currentAction = EZombieCombatAction.DANGER;
+
+    jest.spyOn(math, "random").mockImplementationOnce(() => 26);
+
+    action.initialize();
+
+    expect(object.set_desired_direction).toHaveBeenCalled();
+    expect(object.set_detail_path_type).toHaveBeenCalledWith(move.line);
+    expect(action.previousState).toBeNull();
+    expect(action.enemyLastVertexId).toBeNull();
+    expect(action.enemyLastSeenPosition).toBe(enemy.position());
+    expect(action.enemyLastSeenVertexId).toBe(enemy.level_vertex_id());
+    expect(action.isValidPath).toBe(false);
+    expect(action.turnTime).toBe(0);
+    expect(state.currentAction).toBe(EZombieCombatAction.SHOOT);
+    expect(GlobalSoundManager.getInstance().playSound).not.toHaveBeenCalled();
+
+    jest.spyOn(math, "random").mockImplementationOnce(() => 25);
+
+    action.initialize();
+
+    expect(GlobalSoundManager.getInstance().playSound).toHaveBeenCalledWith(object.id(), "fight_attack");
+  });
+
+  it("should correctly finalize", () => {
+    const enemy: GameObject = mockGameObject();
+    const object: GameObject = mockGameObject({ best_enemy: () => enemy });
+    const state: ISchemeCombatState = mockSchemeState(EScheme.COMBAT);
+    const action: ActionZombieShoot = new ActionZombieShoot(state);
+
+    action.setup(object, new property_storage());
+
+    expect(action.state).toBe(state);
+
+    action.initialize();
+    action.finalize();
+
+    expect(state.currentAction).toBeNull();
+  });
+
+  it.todo("should correctly execute");
+
+  it("should correctly set state", () => {
+    const enemy: GameObject = mockGameObject();
+    const object: GameObject = mockGameObject({ best_enemy: () => enemy });
+    const state: ISchemeCombatState = mockSchemeState(EScheme.COMBAT);
+    const action: ActionZombieShoot = new ActionZombieShoot(state);
+
+    action.setup(object, new property_storage());
+
+    action.setState(EStalkerState.FIRE, null, null);
+
+    expect(action.targetStateDescriptor.lookObjectId).toBeNull();
+    expect(action.targetStateDescriptor.lookPosition).toBeNull();
+
+    expect(setStalkerState).toHaveBeenCalledWith(object, EStalkerState.FIRE, null, null, action.targetStateDescriptor);
+
+    expect(action.previousState).toBe(EStalkerState.FIRE);
+
+    action.enemyLastSeenPosition = MX_VECTOR;
+
+    action.setState(EStalkerState.RAID_FIRE, enemy, ZERO_VECTOR);
+
+    expect(action.targetStateDescriptor.lookObjectId).toBe(enemy.id());
+    expect(action.targetStateDescriptor.lookPosition).toBe(MX_VECTOR);
+
+    expect(setStalkerState).toHaveBeenCalledWith(
+      object,
+      EStalkerState.RAID_FIRE,
+      null,
+      null,
+      action.targetStateDescriptor
+    );
+
+    expect(action.previousState).toBe(EStalkerState.RAID_FIRE);
+  });
+
+  it("should correctly get look direction", () => {
+    const enemy: GameObject = mockGameObject();
+    const object: GameObject = mockGameObject({ position: () => ONE_VECTOR, best_enemy: () => enemy });
+    const state: ISchemeCombatState = mockSchemeState(EScheme.COMBAT);
+    const action: ActionZombieShoot = new ActionZombieShoot(state);
+
+    action.setup(object, new property_storage());
+
+    jest.spyOn(math, "random").mockImplementationOnce(() => 1 / (Math.PI * 2));
+
+    const first: Vector = action.getRandomLookDirection();
+
+    expect(first).toEqual({
+      x: 1.5403023058681398,
+      y: 1,
+      z: 1.8414709848078965,
+    });
+
+    jest.spyOn(math, "random").mockImplementationOnce(() => 1 / (Math.PI * 4));
+
+    const second: Vector = action.getRandomLookDirection();
+
+    expect(second).toEqual({
+      x: 1.8775825618903728,
+      y: 1,
+      z: 1.479425538604203,
+    });
+  });
+
+  it("should correctly handle hit", () => {
+    const enemy: GameObject = mockGameObject();
+    const object: GameObject = mockGameObject({ best_enemy: () => enemy });
+    const state: ISchemeCombatState = mockSchemeState(EScheme.COMBAT);
+    const action: ActionZombieShoot = new ActionZombieShoot(state);
+
+    action.setup(object, new property_storage());
+
+    action.onHit(object, 0.5, ZERO_VECTOR, null, 1);
+
+    expect(action.wasHit).toBe(false);
+    expect(action.enemyLastSeenPosition).toBeNull();
+    expect(action.enemyLastSeenVertexId).toBeNull();
+
+    action.onHit(object, 0.5, ZERO_VECTOR, enemy, 1);
+
+    expect(action.wasHit).toBe(false);
+    expect(action.enemyLastSeenPosition).toBeNull();
+    expect(action.enemyLastSeenVertexId).toBeNull();
+
+    state.currentAction = EZombieCombatAction.SHOOT;
+    action.onHit(object, 0.5, ZERO_VECTOR, enemy, 1);
+
+    expect(action.wasHit).toBe(true);
+    expect(action.enemyLastSeenPosition).toBe(enemy.position());
+    expect(action.enemyLastSeenVertexId).toBe(enemy.level_vertex_id());
+  });
+});

--- a/src/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieShoot.ts
+++ b/src/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieShoot.ts
@@ -34,7 +34,7 @@ export class ActionZombieShoot extends action_base {
 
   public wasHit: boolean = false;
 
-  public enemyLastSeenVertexId!: TNumberId;
+  public enemyLastSeenVertexId: Optional<TNumberId> = null;
   public enemyLastSeenPosition: Optional<Vector> = null;
   public enemyLastVertexId: Optional<TNumberId> = null;
   public enemyLastAccessibleVertexId: Optional<TNumberId> = null;
@@ -106,9 +106,9 @@ export class ActionZombieShoot extends action_base {
       this.enemyLastVertexId = this.enemyLastSeenVertexId;
       this.isValidPath = false;
 
-      if (!this.object.accessible(this.enemyLastSeenVertexId)) {
+      if (!this.object.accessible(this.enemyLastSeenVertexId as TNumberId)) {
         [this.enemyLastAccessibleVertexId, this.enemyLastAccessiblePosition] = this.object.accessible_nearest(
-          level.vertex_position(this.enemyLastSeenVertexId),
+          level.vertex_position(this.enemyLastSeenVertexId as TNumberId),
           ZERO_VECTOR
         );
       } else {
@@ -164,10 +164,10 @@ export class ActionZombieShoot extends action_base {
    * todo: Description.
    */
   public setState(state: EStalkerState, bestEnemy: Optional<GameObject>, position: Optional<Vector>): void {
-    this.targetStateDescriptor.lookObjectId = bestEnemy?.id() as Optional<TNumberId>;
+    this.targetStateDescriptor.lookObjectId = bestEnemy ? bestEnemy.id() : null;
     this.targetStateDescriptor.lookPosition = bestEnemy ? this.enemyLastSeenPosition : position;
 
-    setStalkerState(this.object, state, null, null, this.targetStateDescriptor, null);
+    setStalkerState(this.object, state, null, null, this.targetStateDescriptor);
 
     this.previousState = state;
   }
@@ -179,8 +179,8 @@ export class ActionZombieShoot extends action_base {
     const angle: TRate = math.pi * 2 * math.random();
     const lookPosition: Vector = copyVector(this.object.position());
 
-    lookPosition.x = lookPosition.x + math.cos(angle);
-    lookPosition.z = lookPosition.z + math.sin(angle);
+    lookPosition.x += math.cos(angle);
+    lookPosition.z += math.sin(angle);
 
     return lookPosition;
   }
@@ -188,7 +188,7 @@ export class ActionZombieShoot extends action_base {
   /**
    * todo: Description.
    */
-  public onHit(object: GameObject, amount: TRate, direction: Vector, who: GameObject, boneId: TIndex): void {
+  public onHit(object: GameObject, amount: TRate, direction: Vector, who: Optional<GameObject>, boneId: TIndex): void {
     if (who === null) {
       return;
     }

--- a/src/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieShoot.ts
+++ b/src/engine/core/schemes/stalker/combat_zombied/actions/ActionZombieShoot.ts
@@ -55,6 +55,8 @@ export class ActionZombieShoot extends action_base {
    * todo: Description.
    */
   public override initialize(): void {
+    logger.info("Activate:", this.object.name());
+
     super.initialize();
 
     this.object.set_desired_direction();
@@ -74,6 +76,16 @@ export class ActionZombieShoot extends action_base {
     if (chance(25)) {
       GlobalSoundManager.getInstance().playSound(this.object.id(), "fight_attack");
     }
+  }
+
+  /**
+   * todo: Description.
+   */
+  public override finalize(): void {
+    logger.info("Deactivate:", this.object.name());
+
+    super.finalize();
+    this.state.currentAction = null;
   }
 
   /**
@@ -171,14 +183,6 @@ export class ActionZombieShoot extends action_base {
     lookPosition.z = lookPosition.z + math.sin(angle);
 
     return lookPosition;
-  }
-
-  /**
-   * todo: Description.
-   */
-  public override finalize(): void {
-    super.finalize();
-    this.state.currentAction = null;
   }
 
   /**

--- a/src/engine/core/schemes/stalker/danger/utils/danger_generic.test.ts
+++ b/src/engine/core/schemes/stalker/danger/utils/danger_generic.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { clsid, danger_object } from "xray16";
 
-import { IRegistryObjectState, registerObject, registerSimulator, registry } from "@/engine/core/database";
+import {
+  ILogicsOverrides,
+  IRegistryObjectState,
+  registerObject,
+  registerSimulator,
+  registry,
+} from "@/engine/core/database";
 import { SimulationBoardManager } from "@/engine/core/managers/simulation/SimulationBoardManager";
 import { SmartTerrain, SmartTerrainControl } from "@/engine/core/objects/server/smart_terrain";
 import { ESmartTerrainStatus } from "@/engine/core/objects/server/smart_terrain/smart_terrain_types";
@@ -15,7 +21,7 @@ import { WoundManager } from "@/engine/core/schemes/stalker/wounded/WoundManager
 import { parseConditionsList } from "@/engine/core/utils/ini";
 import { FALSE, TRUE } from "@/engine/lib/constants/words";
 import { EGameObjectRelation, EScheme, GameObject, ServerSmartZoneObject, TClassId } from "@/engine/lib/types";
-import { mockSchemeState } from "@/fixtures/engine";
+import { mockBaseSchemeLogic, mockSchemeState } from "@/fixtures/engine";
 import { replaceFunctionMock } from "@/fixtures/jest";
 import {
   MockDangerObject,
@@ -152,19 +158,19 @@ describe("danger generic utils", () => {
 
     state.enemyId = null;
     combatIgnoreState.overrides = {
-      combat_ignore: {
+      combat_ignore: mockBaseSchemeLogic({
         condlist: parseConditionsList(TRUE),
-      },
-    };
+      }),
+    } as ILogicsOverrides;
     expect(canObjectSelectAsEnemy(object, enemy)).toBe(false);
     expect(state.enemyId).toBe(enemy.id());
 
     state.enemyId = null;
     combatIgnoreState.overrides = {
-      combat_ignore: {
+      combat_ignore: mockBaseSchemeLogic({
         condlist: parseConditionsList(FALSE),
-      },
-    };
+      }),
+    } as ILogicsOverrides;
     expect(canObjectSelectAsEnemy(object, enemy)).toBe(true);
     expect(state.enemyId).toBe(enemy.id());
   });

--- a/src/engine/core/schemes/stalker/danger/utils/danger_generic.test.ts
+++ b/src/engine/core/schemes/stalker/danger/utils/danger_generic.test.ts
@@ -158,7 +158,7 @@ describe("danger generic utils", () => {
 
     state.enemyId = null;
     combatIgnoreState.overrides = {
-      combat_ignore: mockBaseSchemeLogic({
+      combatIgnore: mockBaseSchemeLogic({
         condlist: parseConditionsList(TRUE),
       }),
     } as ILogicsOverrides;
@@ -167,7 +167,7 @@ describe("danger generic utils", () => {
 
     state.enemyId = null;
     combatIgnoreState.overrides = {
-      combat_ignore: mockBaseSchemeLogic({
+      combatIgnore: mockBaseSchemeLogic({
         condlist: parseConditionsList(FALSE),
       }),
     } as ILogicsOverrides;

--- a/src/engine/core/schemes/stalker/danger/utils/danger_generic.ts
+++ b/src/engine/core/schemes/stalker/danger/utils/danger_generic.ts
@@ -1,6 +1,6 @@
 import { danger_object } from "xray16";
 
-import { IRegistryObjectState, registry } from "@/engine/core/database";
+import { ILogicsOverrides, IRegistryObjectState, registry } from "@/engine/core/database";
 import { SimulationBoardManager } from "@/engine/core/managers/simulation/SimulationBoardManager";
 import { SmartTerrain } from "@/engine/core/objects/server/smart_terrain";
 import { ESmartTerrainStatus } from "@/engine/core/objects/server/smart_terrain/smart_terrain_types";
@@ -144,7 +144,7 @@ export function canObjectSelectAsEnemy(object: GameObject, enemy: GameObject): b
   }
 
   // Check if object have any state overrides that cause object to explicitly ignore combat.
-  const stateOverrides: Optional<AnyObject> = combatIgnoreState?.overrides as Optional<AnyObject>;
+  const stateOverrides: Optional<ILogicsOverrides> = combatIgnoreState?.overrides as Optional<ILogicsOverrides>;
 
   if (stateOverrides && stateOverrides.combat_ignore) {
     return pickSectionFromCondList(enemy, object, stateOverrides.combat_ignore.condlist) !== TRUE;

--- a/src/engine/core/schemes/stalker/danger/utils/danger_generic.ts
+++ b/src/engine/core/schemes/stalker/danger/utils/danger_generic.ts
@@ -146,8 +146,8 @@ export function canObjectSelectAsEnemy(object: GameObject, enemy: GameObject): b
   // Check if object have any state overrides that cause object to explicitly ignore combat.
   const stateOverrides: Optional<ILogicsOverrides> = combatIgnoreState?.overrides as Optional<ILogicsOverrides>;
 
-  if (stateOverrides && stateOverrides.combat_ignore) {
-    return pickSectionFromCondList(enemy, object, stateOverrides.combat_ignore.condlist) !== TRUE;
+  if (stateOverrides && stateOverrides.combatIgnore) {
+    return pickSectionFromCondList(enemy, object, stateOverrides.combatIgnore.condlist) !== TRUE;
   }
 
   // When object is critically wounded, it should fight back.

--- a/src/engine/core/schemes/stalker/danger/utils/danger_generic.ts
+++ b/src/engine/core/schemes/stalker/danger/utils/danger_generic.ts
@@ -15,7 +15,6 @@ import { ACTOR_ID } from "@/engine/lib/constants/ids";
 import { MAX_U16 } from "@/engine/lib/constants/memory";
 import { TRUE } from "@/engine/lib/constants/words";
 import {
-  AnyObject,
   DangerObject,
   EGameObjectRelation,
   EScheme,

--- a/src/engine/core/schemes/stalker/reach_task/SchemeReachTask.ts
+++ b/src/engine/core/schemes/stalker/reach_task/SchemeReachTask.ts
@@ -6,7 +6,7 @@ import { ActionReachTaskLocation } from "@/engine/core/schemes/stalker/reach_tas
 import { EvaluatorReachedTaskLocation } from "@/engine/core/schemes/stalker/reach_task/evaluators";
 import { ISchemeReachTaskState } from "@/engine/core/schemes/stalker/reach_task/reach_task_types";
 import { LuaLogger } from "@/engine/core/utils/logging";
-import { ActionBase, ActionPlanner, EScheme, ESchemeType, GameObject, IniFile, TSection } from "@/engine/lib/types";
+import { ActionPlanner, EScheme, ESchemeType, GameObject, IniFile, TSection } from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename);
 

--- a/src/engine/core/ui/debug/sections/DebugGeneralSection.ts
+++ b/src/engine/core/ui/debug/sections/DebugGeneralSection.ts
@@ -114,6 +114,10 @@ export class DebugGeneralSection extends AbstractDebugSection {
   public onToggleProfilingButtonClick(): void {
     const profilingManager: ProfilingManager = ProfilingManager.getInstance();
 
+    if (debug === null) {
+      return logger.info("Cannot use profiling - debug module is not present");
+    }
+
     if (profilingManager.isProfilingStarted) {
       profilingManager.clearHook();
     } else {

--- a/src/engine/core/ui/menu/extensions/ExtensionsDialog.ts
+++ b/src/engine/core/ui/menu/extensions/ExtensionsDialog.ts
@@ -88,6 +88,10 @@ export class ExtensionsDialog extends CUIScriptWnd {
 
     this.uiItemsList = initializeElement(this.xml, EElementType.LIST_BOX, "items_list", this, {
       [ui_events.LIST_ITEM_SELECT]: () => this.onActiveExtensionChange(),
+      [ui_events.WINDOW_LBUTTON_DB_CLICK]: () => {
+        this.onActiveExtensionChange();
+        this.onToggleButtonClick();
+      },
     });
     this.uiItemsList.ShowSelectedItem(true);
 

--- a/src/engine/core/ui/menu/options/OptionsVideo.ts
+++ b/src/engine/core/ui/menu/options/OptionsVideo.ts
@@ -1,4 +1,4 @@
-import { CScriptXmlInit, CUIWindow, LuabindClass, vector2 } from "xray16";
+import { CScriptXmlInit, CUIWindow, LuabindClass } from "xray16";
 
 import { Options } from "@/engine/core/ui/menu/options/Options";
 import { LuaLogger } from "@/engine/core/utils/logging";

--- a/src/engine/core/utils/ini/ini_config.test.ts
+++ b/src/engine/core/utils/ini/ini_config.test.ts
@@ -68,9 +68,11 @@ describe("config utils for ini file", () => {
     expect(getObjectConfigOverrides(mockIniFile("test.ltx", { empty: {} }), "empty", object)).toEqualLuaTables({
       combat_ignore: null,
       combat_ignore_keep_when_attacked: false,
-      combat_type: null,
+      combatType: null,
+      scriptCombatType: null,
       maxPostCombatTime: 10,
       minPostCombatTime: 5,
+      heli_hunter: null,
       on_combat: null,
       on_offline_condlist: parseConditionsList(NIL),
       soundgroup: null,
@@ -102,13 +104,14 @@ describe("config utils for ini file", () => {
         p2: null,
       },
       combat_ignore_keep_when_attacked: "third",
-      combat_type: {
+      combatType: {
         condlist: parseConditionsList("fourth"),
         name: "combat_type",
         objectId: null,
         p1: null,
         p2: null,
       },
+      scriptCombatType: null,
       heli_hunter: parseConditionsList("first"),
       maxPostCombatTime: 50,
       minPostCombatTime: 10,
@@ -137,9 +140,11 @@ describe("config utils for ini file", () => {
         object
       )
     ).toEqualLuaTables({
+      heli_hunter: null,
       combat_ignore: null,
       combat_ignore_keep_when_attacked: false,
-      combat_type: null,
+      combatType: null,
+      scriptCombatType: null,
       maxPostCombatTime: 54,
       minPostCombatTime: 15,
       on_combat: null,

--- a/src/engine/core/utils/ini/ini_config.test.ts
+++ b/src/engine/core/utils/ini/ini_config.test.ts
@@ -66,15 +66,15 @@ describe("config utils for ini file", () => {
     const state: IRegistryObjectState = registerObject(object);
 
     expect(getObjectConfigOverrides(mockIniFile("test.ltx", { empty: {} }), "empty", object)).toEqualLuaTables({
-      combat_ignore: null,
-      combat_ignore_keep_when_attacked: false,
+      combatIgnore: null,
+      combatIgnoreKeepWhenAttacked: false,
       combatType: null,
       scriptCombatType: null,
       maxPostCombatTime: 10,
       minPostCombatTime: 5,
-      heli_hunter: null,
-      on_combat: null,
-      on_offline_condlist: parseConditionsList(NIL),
+      heliHunter: null,
+      onCombat: null,
+      onOffline: parseConditionsList(NIL),
       soundgroup: null,
     });
 
@@ -96,14 +96,14 @@ describe("config utils for ini file", () => {
         object
       )
     ).toEqualLuaTables({
-      combat_ignore: {
+      combatIgnore: {
         condlist: parseConditionsList("second"),
         name: "combat_ignore_cond",
         objectId: null,
         p1: null,
         p2: null,
       },
-      combat_ignore_keep_when_attacked: "third",
+      combatIgnoreKeepWhenAttacked: "third",
       combatType: {
         condlist: parseConditionsList("fourth"),
         name: "combat_type",
@@ -112,17 +112,17 @@ describe("config utils for ini file", () => {
         p2: null,
       },
       scriptCombatType: null,
-      heli_hunter: parseConditionsList("first"),
+      heliHunter: parseConditionsList("first"),
       maxPostCombatTime: 50,
       minPostCombatTime: 10,
-      on_combat: {
+      onCombat: {
         condlist: parseConditionsList("fifth"),
         name: "on_combat",
         objectId: null,
         p1: null,
         p2: null,
       },
-      on_offline_condlist: parseConditionsList("sixth"),
+      onOffline: parseConditionsList("sixth"),
       soundgroup: "seventh",
     });
 
@@ -140,15 +140,15 @@ describe("config utils for ini file", () => {
         object
       )
     ).toEqualLuaTables({
-      heli_hunter: null,
-      combat_ignore: null,
-      combat_ignore_keep_when_attacked: false,
+      heliHunter: null,
+      combatIgnore: null,
+      combatIgnoreKeepWhenAttacked: false,
       combatType: null,
       scriptCombatType: null,
       maxPostCombatTime: 54,
       minPostCombatTime: 15,
-      on_combat: null,
-      on_offline_condlist: parseConditionsList(NIL),
+      onCombat: null,
+      onOffline: parseConditionsList(NIL),
       soundgroup: null,
     });
   });

--- a/src/engine/core/utils/ini/ini_config.ts
+++ b/src/engine/core/utils/ini/ini_config.ts
@@ -209,11 +209,11 @@ export function getObjectConfigOverrides(ini: IniFile, section: TSection, object
   return {
     combatType: readIniConditionList(ini, section, "combat_type"),
     scriptCombatType: null,
-    heli_hunter: heliHunter ? parseConditionsList(heliHunter) : null,
+    heliHunter: heliHunter ? parseConditionsList(heliHunter) : null,
     maxPostCombatTime: maxPostCombatTime,
     minPostCombatTime: minPostCombatTime,
-    on_combat: readIniConditionList(ini, section, "on_combat"),
-    on_offline_condlist: parseConditionsList(
+    onCombat: readIniConditionList(ini, section, "on_combat"),
+    onOffline: parseConditionsList(
       readIniString(
         ini,
         ini.line_exist(section, "on_offline") ? section : state.sectionLogic,
@@ -224,8 +224,8 @@ export function getObjectConfigOverrides(ini: IniFile, section: TSection, object
       )
     ),
     soundgroup: readIniString(ini, section, "soundgroup", false),
-    combat_ignore: readIniConditionList(ini, section, "combat_ignore_cond"),
-    combat_ignore_keep_when_attacked: readIniBoolean(ini, section, "combat_ignore_keep_when_attacked", false),
+    combatIgnore: readIniConditionList(ini, section, "combat_ignore_cond"),
+    combatIgnoreKeepWhenAttacked: readIniBoolean(ini, section, "combat_ignore_keep_when_attacked", false),
   };
 }
 

--- a/src/engine/core/utils/ini/ini_config.ts
+++ b/src/engine/core/utils/ini/ini_config.ts
@@ -1,4 +1,4 @@
-import { IBaseSchemeLogic, IRegistryObjectState } from "@/engine/core/database/database_types";
+import { IBaseSchemeLogic, ILogicsOverrides, IRegistryObjectState } from "@/engine/core/database/database_types";
 import { registry } from "@/engine/core/database/registry";
 import { getServerObjectByStoryId } from "@/engine/core/database/story_objects";
 import { combatConfig } from "@/engine/core/schemes/stalker/combat/CombatConfig";
@@ -195,21 +195,9 @@ export function getConfigObjectAndZone(ini: IniFile, section: TSection, field: T
  * @param object - target client object
  * @returns overrides object
  */
-export function getObjectConfigOverrides(ini: IniFile, section: TSection, object: GameObject): AnyObject {
-  const overrides: AnyObject = {};
-  const heliHunter: Optional<string> = readIniString(ini, section, "heli_hunter", false);
-
-  if (heliHunter !== null) {
-    overrides.heli_hunter = parseConditionsList(heliHunter);
-  }
-
-  overrides.combat_ignore = readIniConditionList(ini, section, "combat_ignore_cond");
-  overrides.combat_ignore_keep_when_attacked = readIniBoolean(ini, section, "combat_ignore_keep_when_attacked", false);
-  overrides.combat_type = readIniConditionList(ini, section, "combat_type");
-  overrides.on_combat = readIniConditionList(ini, section, "on_combat");
-
+export function getObjectConfigOverrides(ini: IniFile, section: TSection, object: GameObject): ILogicsOverrides {
   const state: IRegistryObjectState = registry.objects.get(object.id());
-
+  const heliHunter: Optional<string> = readIniString(ini, section, "heli_hunter", false);
   const [minPostCombatTime, maxPostCombatTime] = readIniTwoNumbers(
     ini,
     ini.line_exist(state.sectionLogic, "post_combat_time") ? state.sectionLogic : section,
@@ -218,20 +206,27 @@ export function getObjectConfigOverrides(ini: IniFile, section: TSection, object
     combatConfig.POST_COMBAT_IDLE.MAX / 1000
   );
 
-  overrides.minPostCombatTime = minPostCombatTime;
-  overrides.maxPostCombatTime = maxPostCombatTime;
-
-  if (ini.line_exist(section, "on_offline")) {
-    overrides.on_offline_condlist = parseConditionsList(readIniString(ini, section, "on_offline", false, null, NIL));
-  } else {
-    overrides.on_offline_condlist = parseConditionsList(
-      readIniString(ini, state.sectionLogic, "on_offline", false, null, NIL)
-    );
-  }
-
-  overrides.soundgroup = readIniString(ini, section, "soundgroup", false);
-
-  return overrides;
+  return {
+    combatType: readIniConditionList(ini, section, "combat_type"),
+    scriptCombatType: null,
+    heli_hunter: heliHunter ? parseConditionsList(heliHunter) : null,
+    maxPostCombatTime: maxPostCombatTime,
+    minPostCombatTime: minPostCombatTime,
+    on_combat: readIniConditionList(ini, section, "on_combat"),
+    on_offline_condlist: parseConditionsList(
+      readIniString(
+        ini,
+        ini.line_exist(section, "on_offline") ? section : state.sectionLogic,
+        "on_offline",
+        false,
+        null,
+        NIL
+      )
+    ),
+    soundgroup: readIniString(ini, section, "soundgroup", false),
+    combat_ignore: readIniConditionList(ini, section, "combat_ignore_cond"),
+    combat_ignore_keep_when_attacked: readIniBoolean(ini, section, "combat_ignore_keep_when_attacked", false),
+  };
 }
 
 /**

--- a/src/engine/core/utils/scheme/scheme_logic.test.ts
+++ b/src/engine/core/utils/scheme/scheme_logic.test.ts
@@ -14,7 +14,7 @@ import {
 import { MapDisplayManager } from "@/engine/core/managers/map";
 import { ObjectRestrictionsManager } from "@/engine/core/objects/ai/restriction";
 import { TAbstractSchemeConstructor } from "@/engine/core/objects/ai/scheme";
-import { SmartTerrain } from "@/engine/core/objects/server/smart_terrain";
+import { ISmartTerrainJobDescriptor, SmartTerrain } from "@/engine/core/objects/server/smart_terrain";
 import { SchemeMobCombat } from "@/engine/core/schemes/monster/mob_combat";
 import { SchemeMobDeath } from "@/engine/core/schemes/monster/mob_death";
 import { SchemePhysicalOnHit } from "@/engine/core/schemes/physical/ph_on_hit";
@@ -36,7 +36,6 @@ import { SchemePatrol } from "@/engine/core/schemes/stalker/patrol";
 import { SchemeReachTask } from "@/engine/core/schemes/stalker/reach_task";
 import { SchemeWounded } from "@/engine/core/schemes/stalker/wounded";
 import { disableInfoPortion, giveInfoPortion } from "@/engine/core/utils/info_portion";
-import { ISmartTerrainJobDescriptor } from "@/engine/core/utils/job";
 import {
   activateSchemeBySection,
   enableObjectBaseSchemes,
@@ -263,8 +262,10 @@ describe("scheme logic utils", () => {
 
     expect(state.overrides).toEqualLuaTables({
       combat_ignore: null,
+      heli_hunter: null,
       combat_ignore_keep_when_attacked: false,
-      combat_type: null,
+      combatType: null,
+      scriptCombatType: null,
       maxPostCombatTime: 10,
       minPostCombatTime: 5,
       on_combat: null,

--- a/src/engine/core/utils/scheme/scheme_logic.test.ts
+++ b/src/engine/core/utils/scheme/scheme_logic.test.ts
@@ -261,15 +261,15 @@ describe("scheme logic utils", () => {
     expect(getSchemeAction(state[EScheme.HIT] as IBaseSchemeState).activate).toHaveBeenCalledWith(false, object);
 
     expect(state.overrides).toEqualLuaTables({
-      combat_ignore: null,
-      heli_hunter: null,
-      combat_ignore_keep_when_attacked: false,
+      combatIgnore: null,
+      heliHunter: null,
+      combatIgnoreKeepWhenAttacked: false,
       combatType: null,
       scriptCombatType: null,
       maxPostCombatTime: 10,
       minPostCombatTime: 5,
-      on_combat: null,
-      on_offline_condlist: {
+      onCombat: null,
+      onOffline: {
         "1": {
           infop_check: {},
           infop_set: {},

--- a/src/engine/core/utils/scheme/scheme_logic.ts
+++ b/src/engine/core/utils/scheme/scheme_logic.ts
@@ -29,7 +29,16 @@ import {
   initializeObjectTakeItemsEnabledState,
 } from "@/engine/core/utils/scheme/scheme_object_initialization";
 import { NIL } from "@/engine/lib/constants/words";
-import { EScheme, ESchemeEvent, ESchemeType, GameObject, IniFile, Optional, TSection } from "@/engine/lib/types";
+import {
+  EScheme,
+  ESchemeEvent,
+  ESchemeType,
+  GameObject,
+  IniFile,
+  Optional,
+  TName,
+  TSection,
+} from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename, { file: "scheme" });
 
@@ -97,17 +106,17 @@ export function getSectionToActivate(object: GameObject, ini: IniFile, section: 
  * @param object - target client object
  * @param ini - target object logics ini file
  * @param section - target section to activate
- * @param additional - additional information, usually parent smart terrain name
+ * @param smartTerrainName - smart terrain name
  * @param isLoading - whether loading object on game load, `false` means manual scheme switch
  */
 export function activateSchemeBySection(
   object: GameObject,
   ini: IniFile,
   section: Optional<TSection>,
-  additional: Optional<string>,
+  smartTerrainName: Optional<TName>,
   isLoading: boolean
 ): void {
-  logger.format("Activate scheme: '%s' %s' %s'", object.name(), section, additional);
+  logger.format("Activate scheme: '%s' %s' %s'", object.name(), section, smartTerrainName);
 
   assertDefined(isLoading, "scheme/logic: activateBySection: loading field is null, true || false expected.");
 
@@ -153,7 +162,7 @@ export function activateSchemeBySection(
 
   // logger.info("Set active scheme:", scheme, "->", object.name(), section, additional);
 
-  schemeImplementation.activate(object, ini, scheme, section as TSection, additional);
+  schemeImplementation.activate(object, ini, scheme, section as TSection, smartTerrainName);
 
   state.activeSection = section;
   state.activeScheme = scheme;

--- a/src/engine/core/utils/scheme/scheme_logic.ts
+++ b/src/engine/core/utils/scheme/scheme_logic.ts
@@ -28,16 +28,7 @@ import {
   initializeObjectTakeItemsEnabledState,
 } from "@/engine/core/utils/scheme/scheme_object_initialization";
 import { NIL } from "@/engine/lib/constants/words";
-import {
-  EScheme,
-  ESchemeEvent,
-  ESchemeType,
-  GameObject,
-  IniFile,
-  Optional,
-  TName,
-  TSection,
-} from "@/engine/lib/types";
+import { EScheme, ESchemeEvent, ESchemeType, GameObject, IniFile, Optional, TName, TSection } from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename, { file: "scheme" });
 

--- a/src/engine/core/utils/scheme/scheme_logic.ts
+++ b/src/engine/core/utils/scheme/scheme_logic.ts
@@ -11,7 +11,6 @@ import { MapDisplayManager } from "@/engine/core/managers/map/MapDisplayManager"
 import { ObjectRestrictionsManager } from "@/engine/core/objects/ai/restriction";
 import { TAbstractSchemeConstructor } from "@/engine/core/objects/ai/scheme";
 import { SmartTerrain } from "@/engine/core/objects/server/smart_terrain";
-import { ISmartTerrainJobDescriptor } from "@/engine/core/objects/server/smart_terrain/job/job_types";
 import { assert, assertDefined } from "@/engine/core/utils/assertion";
 import { getObjectConfigOverrides, pickSectionFromCondList } from "@/engine/core/utils/ini/ini_config";
 import { getSchemeFromSection } from "@/engine/core/utils/ini/ini_parse";

--- a/src/engine/core/utils/sound.test.ts
+++ b/src/engine/core/utils/sound.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "@jest/globals";
 import { snd_type } from "xray16";
 
-import { registry } from "@/engine/core/database";
 import { LoopedSound } from "@/engine/core/managers/sounds/objects";
 import { soundsConfig } from "@/engine/core/managers/sounds/SoundsConfig";
 import {

--- a/src/engine/core/utils/sound.ts
+++ b/src/engine/core/utils/sound.ts
@@ -1,6 +1,5 @@
 import { bit_and, snd_type } from "xray16";
 
-import { registry } from "@/engine/core/database";
 import { soundsConfig } from "@/engine/core/managers/sounds/SoundsConfig";
 import { LuaLogger } from "@/engine/core/utils/logging";
 import { ESoundType } from "@/engine/lib/constants/sound";

--- a/src/engine/lib/constants/vectors.ts
+++ b/src/engine/lib/constants/vectors.ts
@@ -6,6 +6,8 @@ import { Vector } from "@/engine/lib/types";
  */
 export const ZERO_VECTOR: Vector = createEmptyVector();
 
+export const ONE_VECTOR: Vector = createVector(1, 1, 1);
+
 export const X_VECTOR: Vector = createVector(1, 0, 0);
 export const MX_VECTOR: Vector = createVector(-1, 0, 0);
 

--- a/src/engine/lib/types/xray.ts
+++ b/src/engine/lib/types/xray.ts
@@ -72,7 +72,6 @@ import {
   noise,
   object_factory,
   particles_object,
-  Patch_Dawnload_Progress,
   patrol,
   physics_element,
   physics_joint,

--- a/src/engine/scripts/register/class_registrator.ts
+++ b/src/engine/scripts/register/class_registrator.ts
@@ -1,4 +1,3 @@
-import { editor } from "xray16";
 
 import { Actor, Monster, Stalker } from "@/engine/core/objects/server/creature";
 import { Helicopter } from "@/engine/core/objects/server/Helicopter";

--- a/src/engine/scripts/register/class_registrator.ts
+++ b/src/engine/scripts/register/class_registrator.ts
@@ -1,4 +1,3 @@
-
 import { Actor, Monster, Stalker } from "@/engine/core/objects/server/creature";
 import { Helicopter } from "@/engine/core/objects/server/Helicopter";
 import {

--- a/src/fixtures/xray/mocks/interface/levelInterface.mock.ts
+++ b/src/fixtures/xray/mocks/interface/levelInterface.mock.ts
@@ -27,6 +27,7 @@ export const mockLevelInterface = {
     });
   }),
   map_add_object_spot: jest.fn(),
+  map_has_object_spot: jest.fn(() => 0),
   name: jest.fn(() => "zaton"),
   object_by_id: jest.fn((id: TNumberId) => {
     const verifiedId: TNumberId = Number.parseInt(String(id));

--- a/src/fixtures/xray/mocks/objects/client/game_object.mock.ts
+++ b/src/fixtures/xray/mocks/objects/client/game_object.mock.ts
@@ -123,6 +123,7 @@ export function mockGameObject({
           .filter(Boolean)
           .forEach((it) => inRestrictions.push(it));
       }),
+    best_enemy: rest.best_enemy ?? jest.fn(() => null),
     best_danger: rest.best_danger ?? jest.fn(() => null),
     bind_object: rest.bind_object ?? jest.fn(),
     bleeding,
@@ -297,6 +298,7 @@ export function mockGameObject({
     set_const_force: rest.set_const_force ?? jest.fn(),
     set_desired_direction: rest.set_desired_direction ?? jest.fn(),
     set_desired_position: rest.set_desired_position ?? jest.fn(),
+    set_detail_path_type: rest.set_detail_path_type ?? jest.fn(),
     set_start_dialog: rest.set_start_dialog ?? jest.fn(),
     set_tip_text: rest.set_tip_text ?? jest.fn(),
     sell_condition: rest.sell_condition ?? jest.fn(),

--- a/src/fixtures/xray/mocks/objects/client/physics_shell.mock.ts
+++ b/src/fixtures/xray/mocks/objects/client/physics_shell.mock.ts
@@ -1,4 +1,4 @@
-import { PhysicsJoint, PhysicsShell, TName } from "@/engine/lib/types";
+import { PhysicsShell, TName } from "@/engine/lib/types";
 import { MockPhysicsJoint } from "@/fixtures/xray/mocks/objects/client/physics_joint.mock";
 
 export class MockPhysicsShell {


### PR DESCRIPTION
## Changes

- Fix issue when zombied used wrong combat scheme
- Fix issue when overrides were mismatched due to bad typing
- Fix crash when try to profile `gold` variant of engine
- Add typing for overrides
- Add strict lint command
- Add double click handler for extension list toggling
- Strict linter fix

## Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are included
- [x] documentation is changed or added
